### PR TITLE
Require rpc/rpc.h in /usr/include/tirpc rather than tirpc/rpc/rpc.h

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -19,7 +19,7 @@ if meson.get_compiler('c').has_header('avahi-client/client.h')
   add_project_arguments('-DHAVE_AVAHI', language: 'c')
 endif
 
-if not meson.get_compiler('c').has_header('tirpc/rpc/rpc.h')
+if not meson.get_compiler('c').has_header('rpc/rpc.h', include_directories: include_directories('/usr/include/tirpc'))
   error('Please install libtirpc headers')
 endif
 


### PR DESCRIPTION
Older versions of tirpc, e.g. 0.2.4 as shipped with RHEL/CentOS 7, fail to build without this patch, because `rpc/rpcb_clnt.h` can not be found as the header check doesn't include `/usr/include/tirpc` directly, but just implicitly via `tirpc/rpc/rpc.h`.

This change was successfully tested on RHEL/CentOS 7, CentOS/RHEL/Rocky 8, CentOS Stream 9 (becoming RHEL/Rocky 9), Fedora 34/35 and Fedora Rawhide (becoming Fedora 36).

```
$ /usr/bin/meson --buildtype=plain --prefix=/usr --libdir=/usr/lib64 --libexecdir=/usr/libexec --bindir=/usr/bin --sbindir=/usr/sbin --includedir=/usr/include --datadir=/usr/share --mandir=/usr/share/man --infodir=/usr/share/info --localedir=/usr/share/locale --sysconfdir=/etc --localstatedir=/var --sharedstatedir=/var/lib --wrap-mode=nodownload --auto-features=enabled . x86_64-redhat-linux-gnu
The Meson build system
Version: 0.55.1
Source dir: /builddir/build/BUILD/liblxi-1.14
Build dir: /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu
Build type: native build
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
Project name: liblxi
Project version: 1.14
Using 'CFLAGS' from environment with value: '-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic'
Using 'LDFLAGS' from environment with value: '-Wl,-z,relro '
Using 'CFLAGS' from environment with value: '-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic'
Using 'LDFLAGS' from environment with value: '-Wl,-z,relro '
C compiler for the host machine: cc (gcc 4.8.5 "cc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)")
C linker for the host machine: cc ld.bfd 2.27-44
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (0.27.1)
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
Run-time dependency avahi-client found: YES 0.6.31
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
Run-time dependency libxml-2.0 found: YES 2.9.1
Run-time dependency threads found: YES
Has header "avahi-client/client.h" : YES 
Has header "tirpc/rpc/rpc.h" : NO 
src/meson.build:23:2: ERROR: Problem encountered: Please install libtirpc headers
A full log can be found at /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-logs/meson-log.txt
$ 
```

```
$ cat x86_64-redhat-linux-gnu/meson-logs/meson-log.txt
Build started at 2022-01-22T00:37:43.997409
Main binary: /usr/bin/python3
Build Options: -Dprefix=/usr -Dbindir=/usr/bin -Ddatadir=/usr/share -Dincludedir=/usr/include -Dinfodir=/usr/share/info -Dlibdir=/usr/lib64 -Dlibexecdir=/usr/libexec -Dlocaledir=/usr/share/locale -Dlocalstatedir=/var -Dmandir=/usr/share/man -Dsbindir=/usr/sbin -Dsharedstatedir=/var/lib -Dsysconfdir=/etc -Dauto_features=enabled -Dbuildtype=plain -Dwrap_mode=nodownload
Python system: Linux
The Meson build system
Version: 0.55.1
Source dir: /builddir/build/BUILD/liblxi-1.14
Build dir: /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu
Build type: native build
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
Project name: liblxi
Project version: 1.14
None of 'CC' are defined in the environment, not changing global flags.
Using 'CFLAGS' from environment with value: '-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic'
Using 'LDFLAGS' from environment with value: '-Wl,-z,relro '
None of 'CPPFLAGS' are defined in the environment, not changing global flags.
None of 'CC_LD' are defined in the environment, not changing global flags.
Sanity testing C compiler: cc
Is cross compiler: False.
None of 'CC_LD' are defined in the environment, not changing global flags.
Sanity check compiler command line: cc /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/sanitycheckc.c -o /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/sanitycheckc.exe -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -pipe -D_FILE_OFFSET_BITS=64 -Wl,-z,relro
Sanity check compile stdout:
-----
Sanity check compile stderr:
-----
Running test binary command: /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/sanitycheckc.exe
C compiler for the build machine: cc (gcc 4.8.5 "cc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)")
C linker for the build machine: cc ld.bfd 2.27-44
None of 'AR' are defined in the environment, not changing global flags.
None of 'CC' are defined in the environment, not changing global flags.
Using 'CFLAGS' from environment with value: '-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic'
Using 'LDFLAGS' from environment with value: '-Wl,-z,relro '
None of 'CPPFLAGS' are defined in the environment, not changing global flags.
None of 'CC_LD' are defined in the environment, not changing global flags.
Sanity testing C compiler: cc
Is cross compiler: False.
None of 'CC_LD' are defined in the environment, not changing global flags.
Sanity check compiler command line: cc /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/sanitycheckc.c -o /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/sanitycheckc.exe -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -pipe -D_FILE_OFFSET_BITS=64 -Wl,-z,relro
Sanity check compile stdout:
-----
Sanity check compile stderr:
-----
Running test binary command: /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/sanitycheckc.exe
C compiler for the host machine: cc (gcc 4.8.5 "cc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)")
C linker for the host machine: cc ld.bfd 2.27-44
None of 'AR' are defined in the environment, not changing global flags.
Build machine cpu family: x86_64
Build machine cpu: x86_64
Host machine cpu family: x86_64
Host machine cpu: x86_64
Target machine cpu family: x86_64
Target machine cpu: x86_64
Pkg-config binary for MachineChoice.HOST is not cached.
None of 'PKG_CONFIG' are defined in the environment, not changing global flags.
Pkg-config binary missing from cross or native file, or env var undefined.
Trying a default Pkg-config fallback at pkg-config
Found pkg-config: /usr/bin/pkg-config (0.27.1)
Determining dependency 'avahi-client' with pkg-config executable '/usr/bin/pkg-config'
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config --modversion avahi-client` -> 0
0.6.31
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config --cflags avahi-client` -> 0
-D_REENTRANT
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config avahi-client --libs` -> 0
-L/usr/lib64 -lavahi-common -lavahi-client
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config avahi-client --libs` -> 0
-lavahi-common -lavahi-client
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
None of 'CC_LD' are defined in the environment, not changing global flags.
Running compile:
Working directory:  /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp0fauk7pc
Command line:  cc /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp0fauk7pc/testfile.c -o /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp0fauk7pc/output.exe -pipe -O2 -g -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_FILE_OFFSET_BITS=64 -O0 -Wl,-z,relro 
Code:
 #include<stdio.h>
        
        int main(void) {
            printf("%ld\n", (long)(sizeof(void *)));
            return 0;
        };
Compiler stdout:
 
Compiler stderr:
 In file included from /usr/include/stdio.h:27:0,
                 from /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp0fauk7pc/testfile.c:1:
/usr/include/features.h:330:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
Program stdout:
8
Program stderr:
Running compile:
Working directory:  /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp5srfizd8
Command line:  cc /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp5srfizd8/testfile.c -o /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp5srfizd8/output.obj -pipe -c -O2 -g -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_FILE_OFFSET_BITS=64 -O0 --print-search-dirs 
Code:
 
Compiler stdout:
 install: /usr/lib/gcc/x86_64-redhat-linux/4.8.5/
programs: =/usr/libexec/gcc/x86_64-redhat-linux/4.8.5/:/usr/libexec/gcc/x86_64-redhat-linux/4.8.5/:/usr/libexec/gcc/x86_64-redhat-linux/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/:/usr/lib/gcc/x86_64-redhat-linux/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../x86_64-redhat-linux/bin/x86_64-redhat-linux/4.8.5/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../x86_64-redhat-linux/bin/
libraries: =/usr/lib/gcc/x86_64-redhat-linux/4.8.5/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../x86_64-redhat-linux/lib/x86_64-redhat-linux/4.8.5/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../x86_64-redhat-linux/lib/../lib64/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../x86_64-redhat-linux/4.8.5/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../lib64/:/lib/x86_64-redhat-linux/4.8.5/:/lib/../lib64/:/usr/lib/x86_64-redhat-linux/4.8.5/:/usr/lib/../lib64/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../../x86_64-redhat-linux/lib/:/usr/lib/gcc/x86_64-redhat-linux/4.8.5/../../../:/lib/:/usr/lib/
Compiler stderr:
 
Run-time dependency avahi-client found: YES 0.6.31
Pkg-config binary for MachineChoice.HOST is cached.
Determining dependency 'libxml-2.0' with pkg-config executable '/usr/bin/pkg-config'
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config --modversion libxml-2.0` -> 0
2.9.1
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config --cflags libxml-2.0` -> 0
-I/usr/include/libxml2
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config libxml-2.0 --libs` -> 0
-L/usr/lib64 -lxml2
PKG_CONFIG_PATH: :/usr/lib64/pkgconfig:/usr/share/pkgconfig
Called `/usr/bin/pkg-config libxml-2.0 --libs` -> 0
-lxml2
Using 'PKG_CONFIG_PATH' from environment with value: ':/usr/lib64/pkgconfig:/usr/share/pkgconfig'
Run-time dependency libxml-2.0 found: YES 2.9.1
Run-time dependency threads found: YES
Running compile:
Working directory:  /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp4l34q8s4
Command line:  cc /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp4l34q8s4/testfile.c -pipe -E -P -O2 -g -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_FILE_OFFSET_BITS=64 -P -O0 -std=gnu11 
Code:
 
        #ifdef __has_include
         #if !__has_include("avahi-client/client.h")
          #error "Header 'avahi-client/client.h' could not be found"
         #endif
        #else
         #include <avahi-client/client.h>
        #endif
Compiler stdout:
 typedef signed char int8_t;
typedef short int int16_t;
typedef int int32_t;
typedef long int int64_t;
typedef unsigned char uint8_t;
typedef unsigned short int uint16_t;
typedef unsigned int uint32_t;
typedef unsigned long int uint64_t;
typedef signed char int_least8_t;
typedef short int int_least16_t;
typedef int int_least32_t;
typedef long int int_least64_t;
typedef unsigned char uint_least8_t;
typedef unsigned short int uint_least16_t;
typedef unsigned int uint_least32_t;
typedef unsigned long int uint_least64_t;
typedef signed char int_fast8_t;
typedef long int int_fast16_t;
typedef long int int_fast32_t;
typedef long int int_fast64_t;
typedef unsigned char uint_fast8_t;
typedef unsigned long int uint_fast16_t;
typedef unsigned long int uint_fast32_t;
typedef unsigned long int uint_fast64_t;
typedef long int intptr_t;
typedef unsigned long int uintptr_t;
typedef long int intmax_t;
typedef unsigned long int uintmax_t;
typedef int __gwchar_t;
typedef struct
  {
    long int quot;
    long int rem;
  } imaxdiv_t;
extern intmax_t imaxabs (intmax_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
extern imaxdiv_t imaxdiv (intmax_t __numer, intmax_t __denom)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
extern intmax_t strtoimax (const char *__restrict __nptr,
      char **__restrict __endptr, int __base) __attribute__ ((__nothrow__ , __leaf__));
extern uintmax_t strtoumax (const char *__restrict __nptr,
       char ** __restrict __endptr, int __base) __attribute__ ((__nothrow__ , __leaf__));
extern intmax_t wcstoimax (const __gwchar_t *__restrict __nptr,
      __gwchar_t **__restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__));
extern uintmax_t wcstoumax (const __gwchar_t *__restrict __nptr,
       __gwchar_t ** __restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__));
typedef unsigned char __u_char;
typedef unsigned short int __u_short;
typedef unsigned int __u_int;
typedef unsigned long int __u_long;
typedef signed char __int8_t;
typedef unsigned char __uint8_t;
typedef signed short int __int16_t;
typedef unsigned short int __uint16_t;
typedef signed int __int32_t;
typedef unsigned int __uint32_t;
typedef signed long int __int64_t;
typedef unsigned long int __uint64_t;
typedef long int __quad_t;
typedef unsigned long int __u_quad_t;
typedef unsigned long int __dev_t;
typedef unsigned int __uid_t;
typedef unsigned int __gid_t;
typedef unsigned long int __ino_t;
typedef unsigned long int __ino64_t;
typedef unsigned int __mode_t;
typedef unsigned long int __nlink_t;
typedef long int __off_t;
typedef long int __off64_t;
typedef int __pid_t;
typedef struct { int __val[2]; } __fsid_t;
typedef long int __clock_t;
typedef unsigned long int __rlim_t;
typedef unsigned long int __rlim64_t;
typedef unsigned int __id_t;
typedef long int __time_t;
typedef unsigned int __useconds_t;
typedef long int __suseconds_t;
typedef int __daddr_t;
typedef int __key_t;
typedef int __clockid_t;
typedef void * __timer_t;
typedef long int __blksize_t;
typedef long int __blkcnt_t;
typedef long int __blkcnt64_t;
typedef unsigned long int __fsblkcnt_t;
typedef unsigned long int __fsblkcnt64_t;
typedef unsigned long int __fsfilcnt_t;
typedef unsigned long int __fsfilcnt64_t;
typedef long int __fsword_t;
typedef long int __ssize_t;
typedef long int __syscall_slong_t;
typedef unsigned long int __syscall_ulong_t;
typedef __off64_t __loff_t;
typedef __quad_t *__qaddr_t;
typedef char *__caddr_t;
typedef long int __intptr_t;
typedef unsigned int __socklen_t;
typedef __u_char u_char;
typedef __u_short u_short;
typedef __u_int u_int;
typedef __u_long u_long;
typedef __quad_t quad_t;
typedef __u_quad_t u_quad_t;
typedef __fsid_t fsid_t;
typedef __loff_t loff_t;
typedef __ino64_t ino_t;
typedef __dev_t dev_t;
typedef __gid_t gid_t;
typedef __mode_t mode_t;
typedef __nlink_t nlink_t;
typedef __uid_t uid_t;
typedef __off64_t off_t;
typedef __pid_t pid_t;
typedef __id_t id_t;
typedef __ssize_t ssize_t;
typedef __daddr_t daddr_t;
typedef __caddr_t caddr_t;
typedef __key_t key_t;
typedef __clock_t clock_t;
typedef __time_t time_t;
typedef __clockid_t clockid_t;
typedef __timer_t timer_t;
typedef long unsigned int size_t;
typedef unsigned long int ulong;
typedef unsigned short int ushort;
typedef unsigned int uint;
typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
typedef int register_t __attribute__ ((__mode__ (__word__)));
static __inline unsigned int
__bswap_32 (unsigned int __bsx)
{
  return __builtin_bswap32 (__bsx);
}
static __inline __uint64_t
__bswap_64 (__uint64_t __bsx)
{
  return __builtin_bswap64 (__bsx);
}
typedef int __sig_atomic_t;
typedef struct
  {
    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
  } __sigset_t;
typedef __sigset_t sigset_t;
struct timespec
  {
    __time_t tv_sec;
    __syscall_slong_t tv_nsec;
  };
struct timeval
  {
    __time_t tv_sec;
    __suseconds_t tv_usec;
  };
typedef __suseconds_t suseconds_t;
typedef long int __fd_mask;
typedef struct
  {
    __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
  } fd_set;
typedef __fd_mask fd_mask;
extern int select (int __nfds, fd_set *__restrict __readfds,
     fd_set *__restrict __writefds,
     fd_set *__restrict __exceptfds,
     struct timeval *__restrict __timeout);
extern int pselect (int __nfds, fd_set *__restrict __readfds,
      fd_set *__restrict __writefds,
      fd_set *__restrict __exceptfds,
      const struct timespec *__restrict __timeout,
      const __sigset_t *__restrict __sigmask);
__extension__
extern unsigned int gnu_dev_major (unsigned long long int __dev)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
__extension__
extern unsigned int gnu_dev_minor (unsigned long long int __dev)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
__extension__
extern unsigned long long int gnu_dev_makedev (unsigned int __major,
            unsigned int __minor)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
typedef __blksize_t blksize_t;
typedef __blkcnt64_t blkcnt_t;
typedef __fsblkcnt64_t fsblkcnt_t;
typedef __fsfilcnt64_t fsfilcnt_t;
typedef unsigned long int pthread_t;
union pthread_attr_t
{
  char __size[56];
  long int __align;
};
typedef union pthread_attr_t pthread_attr_t;
typedef struct __pthread_internal_list
{
  struct __pthread_internal_list *__prev;
  struct __pthread_internal_list *__next;
} __pthread_list_t;
typedef union
{
  struct __pthread_mutex_s
  {
    int __lock;
    unsigned int __count;
    int __owner;
    unsigned int __nusers;
    int __kind;
    short __spins;
    short __elision;
    __pthread_list_t __list;
  } __data;
  char __size[40];
  long int __align;
} pthread_mutex_t;
typedef union
{
  char __size[4];
  int __align;
} pthread_mutexattr_t;
typedef union
{
  struct
  {
    int __lock;
    unsigned int __futex;
    __extension__ unsigned long long int __total_seq;
    __extension__ unsigned long long int __wakeup_seq;
    __extension__ unsigned long long int __woken_seq;
    void *__mutex;
    unsigned int __nwaiters;
    unsigned int __broadcast_seq;
  } __data;
  char __size[48];
  __extension__ long long int __align;
} pthread_cond_t;
typedef union
{
  char __size[4];
  int __align;
} pthread_condattr_t;
typedef unsigned int pthread_key_t;
typedef int pthread_once_t;
typedef union
{
  struct
  {
    int __lock;
    unsigned int __nr_readers;
    unsigned int __readers_wakeup;
    unsigned int __writer_wakeup;
    unsigned int __nr_readers_queued;
    unsigned int __nr_writers_queued;
    int __writer;
    int __shared;
    unsigned long int __pad1;
    unsigned long int __pad2;
    unsigned int __flags;
  } __data;
  char __size[56];
  long int __align;
} pthread_rwlock_t;
typedef union
{
  char __size[8];
  long int __align;
} pthread_rwlockattr_t;
typedef volatile int pthread_spinlock_t;
typedef union
{
  char __size[32];
  long int __align;
} pthread_barrier_t;
typedef union
{
  char __size[4];
  int __align;
} pthread_barrierattr_t;
typedef int AvahiProtocol;
typedef int AvahiIfIndex;
enum {
    AVAHI_PROTO_INET = 0,
    AVAHI_PROTO_INET6 = 1,
    AVAHI_PROTO_UNSPEC = -1
};
enum {
    AVAHI_IF_UNSPEC = -1
};
typedef struct AvahiIPv4Address {
    uint32_t address;
} AvahiIPv4Address;
typedef struct AvahiIPv6Address {
    uint8_t address[16];
} AvahiIPv6Address;
typedef struct AvahiAddress {
    AvahiProtocol proto;
    union {
        AvahiIPv6Address ipv6;
        AvahiIPv4Address ipv4;
        uint8_t data[1];
    } data;
} AvahiAddress;
int avahi_address_cmp(const AvahiAddress *a, const AvahiAddress *b);
char *avahi_address_snprint(char *ret_s, size_t length, const AvahiAddress *a);
AvahiAddress *avahi_address_parse(const char *s, AvahiProtocol af, AvahiAddress *ret_addr);
char* avahi_reverse_lookup_name(const AvahiAddress *a, char *ret_s, size_t length);
int avahi_proto_to_af(AvahiProtocol proto);
AvahiProtocol avahi_af_to_proto(int af);
const char* avahi_proto_to_string(AvahiProtocol proto);
typedef __builtin_va_list __gnuc_va_list;
typedef __gnuc_va_list va_list;
typedef struct AvahiStringList {
    struct AvahiStringList *next;
    size_t size;
    uint8_t text[1];
} AvahiStringList;
AvahiStringList *avahi_string_list_new(const char *txt, ...) __attribute__ ((sentinel));
AvahiStringList *avahi_string_list_new_va(va_list va);
AvahiStringList *avahi_string_list_new_from_array(const char **array, int length);
void avahi_string_list_free(AvahiStringList *l);
AvahiStringList *avahi_string_list_add(AvahiStringList *l, const char *text);
AvahiStringList *avahi_string_list_add_printf(AvahiStringList *l, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
AvahiStringList *avahi_string_list_add_vprintf(AvahiStringList *l, const char *format, va_list va);
AvahiStringList *avahi_string_list_add_arbitrary(AvahiStringList *l, const uint8_t *text, size_t size);
AvahiStringList*avahi_string_list_add_anonymous(AvahiStringList *l, size_t size);
AvahiStringList *avahi_string_list_add_many(AvahiStringList *r, ...) __attribute__ ((sentinel));
AvahiStringList *avahi_string_list_add_many_va(AvahiStringList *r, va_list va);
char* avahi_string_list_to_string(AvahiStringList *l);
size_t avahi_string_list_serialize(AvahiStringList *l, void * data, size_t size);
int avahi_string_list_parse(const void *data, size_t size, AvahiStringList **ret);
int avahi_string_list_equal(const AvahiStringList *a, const AvahiStringList *b);
AvahiStringList *avahi_string_list_copy(const AvahiStringList *l);
AvahiStringList* avahi_string_list_reverse(AvahiStringList *l);
unsigned avahi_string_list_length(const AvahiStringList *l);
AvahiStringList *avahi_string_list_get_next(AvahiStringList *l);
uint8_t *avahi_string_list_get_text(AvahiStringList *l);
size_t avahi_string_list_get_size(AvahiStringList *l);
AvahiStringList *avahi_string_list_find(AvahiStringList *l, const char *key);
int avahi_string_list_get_pair(AvahiStringList *l, char **key, char **value, size_t *size);
AvahiStringList *avahi_string_list_add_pair(AvahiStringList *l, const char *key, const char *value);
AvahiStringList *avahi_string_list_add_pair_arbitrary(AvahiStringList *l, const char *key, const uint8_t *value, size_t size);
uint32_t avahi_string_list_get_service_cookie(AvahiStringList *l);
typedef enum {
    AVAHI_SERVER_INVALID,
    AVAHI_SERVER_REGISTERING,
    AVAHI_SERVER_RUNNING,
    AVAHI_SERVER_COLLISION,
    AVAHI_SERVER_FAILURE
} AvahiServerState;
typedef enum {
    AVAHI_ENTRY_GROUP_UNCOMMITED,
    AVAHI_ENTRY_GROUP_REGISTERING,
    AVAHI_ENTRY_GROUP_ESTABLISHED,
    AVAHI_ENTRY_GROUP_COLLISION,
    AVAHI_ENTRY_GROUP_FAILURE
} AvahiEntryGroupState;
typedef enum {
    AVAHI_PUBLISH_UNIQUE = 1,
    AVAHI_PUBLISH_NO_PROBE = 2,
    AVAHI_PUBLISH_NO_ANNOUNCE = 4,
    AVAHI_PUBLISH_ALLOW_MULTIPLE = 8,
    AVAHI_PUBLISH_NO_REVERSE = 16,
    AVAHI_PUBLISH_NO_COOKIE = 32,
    AVAHI_PUBLISH_UPDATE = 64,
    AVAHI_PUBLISH_USE_WIDE_AREA = 128,
    AVAHI_PUBLISH_USE_MULTICAST = 256
} AvahiPublishFlags;
typedef enum {
    AVAHI_LOOKUP_USE_WIDE_AREA = 1,
    AVAHI_LOOKUP_USE_MULTICAST = 2,
    AVAHI_LOOKUP_NO_TXT = 4,
    AVAHI_LOOKUP_NO_ADDRESS = 8
} AvahiLookupFlags;
typedef enum {
    AVAHI_LOOKUP_RESULT_CACHED = 1,
    AVAHI_LOOKUP_RESULT_WIDE_AREA = 2,
    AVAHI_LOOKUP_RESULT_MULTICAST = 4,
    AVAHI_LOOKUP_RESULT_LOCAL = 8,
    AVAHI_LOOKUP_RESULT_OUR_OWN = 16,
    AVAHI_LOOKUP_RESULT_STATIC = 32
} AvahiLookupResultFlags;
typedef enum {
    AVAHI_BROWSER_NEW,
    AVAHI_BROWSER_REMOVE,
    AVAHI_BROWSER_CACHE_EXHAUSTED,
    AVAHI_BROWSER_ALL_FOR_NOW,
    AVAHI_BROWSER_FAILURE
} AvahiBrowserEvent;
typedef enum {
    AVAHI_RESOLVER_FOUND,
    AVAHI_RESOLVER_FAILURE
} AvahiResolverEvent;
typedef enum {
    AVAHI_DOMAIN_BROWSER_BROWSE,
    AVAHI_DOMAIN_BROWSER_BROWSE_DEFAULT,
    AVAHI_DOMAIN_BROWSER_REGISTER,
    AVAHI_DOMAIN_BROWSER_REGISTER_DEFAULT,
    AVAHI_DOMAIN_BROWSER_BROWSE_LEGACY,
    AVAHI_DOMAIN_BROWSER_MAX
} AvahiDomainBrowserType;
enum {
    AVAHI_DNS_TYPE_A = 0x01,
    AVAHI_DNS_TYPE_NS = 0x02,
    AVAHI_DNS_TYPE_CNAME = 0x05,
    AVAHI_DNS_TYPE_SOA = 0x06,
    AVAHI_DNS_TYPE_PTR = 0x0C,
    AVAHI_DNS_TYPE_HINFO = 0x0D,
    AVAHI_DNS_TYPE_MX = 0x0F,
    AVAHI_DNS_TYPE_TXT = 0x10,
    AVAHI_DNS_TYPE_AAAA = 0x1C,
    AVAHI_DNS_TYPE_SRV = 0x21
};
enum {
    AVAHI_DNS_CLASS_IN = 0x01
};
typedef unsigned long int nfds_t;
struct pollfd
  {
    int fd;
    short int events;
    short int revents;
  };
extern int poll (struct pollfd *__fds, nfds_t __nfds, int __timeout);
struct timezone
  {
    int tz_minuteswest;
    int tz_dsttime;
  };
typedef struct timezone *__restrict __timezone_ptr_t;
extern int gettimeofday (struct timeval *__restrict __tv,
    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int settimeofday (const struct timeval *__tv,
    const struct timezone *__tz)
     __attribute__ ((__nothrow__ , __leaf__));
extern int adjtime (const struct timeval *__delta,
      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
enum __itimer_which
  {
    ITIMER_REAL = 0,
    ITIMER_VIRTUAL = 1,
    ITIMER_PROF = 2
  };
struct itimerval
  {
    struct timeval it_interval;
    struct timeval it_value;
  };
typedef int __itimer_which_t;
extern int getitimer (__itimer_which_t __which,
        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
extern int setitimer (__itimer_which_t __which,
        const struct itimerval *__restrict __new,
        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
extern int utimes (const char *__file, const struct timeval __tvp[2])
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int lutimes (const char *__file, const struct timeval __tvp[2])
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
typedef struct AvahiWatch AvahiWatch;
typedef struct AvahiTimeout AvahiTimeout;
typedef struct AvahiPoll AvahiPoll;
typedef enum {
    AVAHI_WATCH_IN = 0x001,
    AVAHI_WATCH_OUT = 0x004,
    AVAHI_WATCH_ERR = 0x008,
    AVAHI_WATCH_HUP = 0x010
} AvahiWatchEvent;
typedef void (*AvahiWatchCallback)(AvahiWatch *w, int fd, AvahiWatchEvent event, void *userdata);
typedef void (*AvahiTimeoutCallback)(AvahiTimeout *t, void *userdata);
struct AvahiPoll {
    void* userdata;
    AvahiWatch* (*watch_new)(const AvahiPoll *api, int fd, AvahiWatchEvent event, AvahiWatchCallback callback, void *userdata);
    void (*watch_update)(AvahiWatch *w, AvahiWatchEvent event);
    AvahiWatchEvent (*watch_get_events)(AvahiWatch *w);
    void (*watch_free)(AvahiWatch *w);
    AvahiTimeout* (*timeout_new)(const AvahiPoll *api, const struct timeval *tv, AvahiTimeoutCallback callback, void *userdata);
    void (*timeout_update)(AvahiTimeout *, const struct timeval *tv);
    void (*timeout_free)(AvahiTimeout *t);
};
typedef struct AvahiClient AvahiClient;
typedef enum {
    AVAHI_CLIENT_S_REGISTERING = AVAHI_SERVER_REGISTERING,
    AVAHI_CLIENT_S_RUNNING = AVAHI_SERVER_RUNNING,
    AVAHI_CLIENT_S_COLLISION = AVAHI_SERVER_COLLISION,
    AVAHI_CLIENT_FAILURE = 100,
    AVAHI_CLIENT_CONNECTING = 101
} AvahiClientState;
typedef enum {
    AVAHI_CLIENT_IGNORE_USER_CONFIG = 1,
    AVAHI_CLIENT_NO_FAIL = 2
} AvahiClientFlags;
typedef void (*AvahiClientCallback) (
    AvahiClient *s,
    AvahiClientState state ,
    void* userdata );
AvahiClient* avahi_client_new (
    const AvahiPoll *poll_api ,
    AvahiClientFlags flags ,
    AvahiClientCallback callback ,
    void *userdata ,
    int *error );
void avahi_client_free(AvahiClient *client);
const char* avahi_client_get_version_string (AvahiClient*);
const char* avahi_client_get_host_name (AvahiClient*);
int avahi_client_set_host_name(AvahiClient*, const char *name);
const char* avahi_client_get_domain_name (AvahiClient*);
const char* avahi_client_get_host_name_fqdn (AvahiClient*);
AvahiClientState avahi_client_get_state(AvahiClient *client);
int avahi_client_errno (AvahiClient*);
uint32_t avahi_client_get_local_service_cookie(AvahiClient *client);
int avahi_nss_support(void);
Compiler stderr:
 In file included from /usr/include/inttypes.h:25:0,
                 from /usr/include/avahi-client/client.h:23,
                 from /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmp4l34q8s4/testfile.c:7:
/usr/include/features.h:330:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
Has header "avahi-client/client.h" : YES 
Running compile:
Working directory:  /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmpc_gl6r01
Command line:  cc /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmpc_gl6r01/testfile.c -pipe -E -P -O2 -g -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_FILE_OFFSET_BITS=64 -P -O0 -std=gnu11 
Code:
 
        #ifdef __has_include
         #if !__has_include("tirpc/rpc/rpc.h")
          #error "Header 'tirpc/rpc/rpc.h' could not be found"
         #endif
        #else
         #include <tirpc/rpc/rpc.h>
        #endif
Compiler stdout:
 typedef int bool_t;
typedef int enum_t;
typedef unsigned long rpcprog_t;
typedef unsigned long rpcvers_t;
typedef unsigned long rpcproc_t;
typedef unsigned long rpcprot_t;
typedef unsigned long rpcport_t;
typedef long unsigned int size_t;
typedef int wchar_t;
typedef unsigned char __u_char;
typedef unsigned short int __u_short;
typedef unsigned int __u_int;
typedef unsigned long int __u_long;
typedef signed char __int8_t;
typedef unsigned char __uint8_t;
typedef signed short int __int16_t;
typedef unsigned short int __uint16_t;
typedef signed int __int32_t;
typedef unsigned int __uint32_t;
typedef signed long int __int64_t;
typedef unsigned long int __uint64_t;
typedef long int __quad_t;
typedef unsigned long int __u_quad_t;
typedef unsigned long int __dev_t;
typedef unsigned int __uid_t;
typedef unsigned int __gid_t;
typedef unsigned long int __ino_t;
typedef unsigned long int __ino64_t;
typedef unsigned int __mode_t;
typedef unsigned long int __nlink_t;
typedef long int __off_t;
typedef long int __off64_t;
typedef int __pid_t;
typedef struct { int __val[2]; } __fsid_t;
typedef long int __clock_t;
typedef unsigned long int __rlim_t;
typedef unsigned long int __rlim64_t;
typedef unsigned int __id_t;
typedef long int __time_t;
typedef unsigned int __useconds_t;
typedef long int __suseconds_t;
typedef int __daddr_t;
typedef int __key_t;
typedef int __clockid_t;
typedef void * __timer_t;
typedef long int __blksize_t;
typedef long int __blkcnt_t;
typedef long int __blkcnt64_t;
typedef unsigned long int __fsblkcnt_t;
typedef unsigned long int __fsblkcnt64_t;
typedef unsigned long int __fsfilcnt_t;
typedef unsigned long int __fsfilcnt64_t;
typedef long int __fsword_t;
typedef long int __ssize_t;
typedef long int __syscall_slong_t;
typedef unsigned long int __syscall_ulong_t;
typedef __off64_t __loff_t;
typedef __quad_t *__qaddr_t;
typedef char *__caddr_t;
typedef long int __intptr_t;
typedef unsigned int __socklen_t;
static __inline unsigned int
__bswap_32 (unsigned int __bsx)
{
  return __builtin_bswap32 (__bsx);
}
static __inline __uint64_t
__bswap_64 (__uint64_t __bsx)
{
  return __builtin_bswap64 (__bsx);
}
union wait
  {
    int w_status;
    struct
      {
 unsigned int __w_termsig:7;
 unsigned int __w_coredump:1;
 unsigned int __w_retcode:8;
 unsigned int:16;
      } __wait_terminated;
    struct
      {
 unsigned int __w_stopval:8;
 unsigned int __w_stopsig:8;
 unsigned int:16;
      } __wait_stopped;
  };
typedef union
  {
    union wait *__uptr;
    int *__iptr;
  } __WAIT_STATUS __attribute__ ((__transparent_union__));
typedef struct
  {
    int quot;
    int rem;
  } div_t;
typedef struct
  {
    long int quot;
    long int rem;
  } ldiv_t;
__extension__ typedef struct
  {
    long long int quot;
    long long int rem;
  } lldiv_t;
extern size_t __ctype_get_mb_cur_max (void) __attribute__ ((__nothrow__ , __leaf__)) ;
extern double atof (const char *__nptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
extern int atoi (const char *__nptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
extern long int atol (const char *__nptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
__extension__ extern long long int atoll (const char *__nptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
extern double strtod (const char *__restrict __nptr,
        char **__restrict __endptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern float strtof (const char *__restrict __nptr,
       char **__restrict __endptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern long double strtold (const char *__restrict __nptr,
       char **__restrict __endptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern long int strtol (const char *__restrict __nptr,
   char **__restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern unsigned long int strtoul (const char *__restrict __nptr,
      char **__restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
__extension__
extern long long int strtoq (const char *__restrict __nptr,
        char **__restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
__extension__
extern unsigned long long int strtouq (const char *__restrict __nptr,
           char **__restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
__extension__
extern long long int strtoll (const char *__restrict __nptr,
         char **__restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
__extension__
extern unsigned long long int strtoull (const char *__restrict __nptr,
     char **__restrict __endptr, int __base)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern char *l64a (long int __n) __attribute__ ((__nothrow__ , __leaf__)) ;
extern long int a64l (const char *__s)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1))) ;
typedef __u_char u_char;
typedef __u_short u_short;
typedef __u_int u_int;
typedef __u_long u_long;
typedef __quad_t quad_t;
typedef __u_quad_t u_quad_t;
typedef __fsid_t fsid_t;
typedef __loff_t loff_t;
typedef __ino64_t ino_t;
typedef __dev_t dev_t;
typedef __gid_t gid_t;
typedef __mode_t mode_t;
typedef __nlink_t nlink_t;
typedef __uid_t uid_t;
typedef __off64_t off_t;
typedef __pid_t pid_t;
typedef __id_t id_t;
typedef __ssize_t ssize_t;
typedef __daddr_t daddr_t;
typedef __caddr_t caddr_t;
typedef __key_t key_t;
typedef __clock_t clock_t;
typedef __time_t time_t;
typedef __clockid_t clockid_t;
typedef __timer_t timer_t;
typedef unsigned long int ulong;
typedef unsigned short int ushort;
typedef unsigned int uint;
typedef int int8_t __attribute__ ((__mode__ (__QI__)));
typedef int int16_t __attribute__ ((__mode__ (__HI__)));
typedef int int32_t __attribute__ ((__mode__ (__SI__)));
typedef int int64_t __attribute__ ((__mode__ (__DI__)));
typedef unsigned int u_int8_t __attribute__ ((__mode__ (__QI__)));
typedef unsigned int u_int16_t __attribute__ ((__mode__ (__HI__)));
typedef unsigned int u_int32_t __attribute__ ((__mode__ (__SI__)));
typedef unsigned int u_int64_t __attribute__ ((__mode__ (__DI__)));
typedef int register_t __attribute__ ((__mode__ (__word__)));
typedef int __sig_atomic_t;
typedef struct
  {
    unsigned long int __val[(1024 / (8 * sizeof (unsigned long int)))];
  } __sigset_t;
typedef __sigset_t sigset_t;
struct timespec
  {
    __time_t tv_sec;
    __syscall_slong_t tv_nsec;
  };
struct timeval
  {
    __time_t tv_sec;
    __suseconds_t tv_usec;
  };
typedef __suseconds_t suseconds_t;
typedef long int __fd_mask;
typedef struct
  {
    __fd_mask __fds_bits[1024 / (8 * (int) sizeof (__fd_mask))];
  } fd_set;
typedef __fd_mask fd_mask;
extern int select (int __nfds, fd_set *__restrict __readfds,
     fd_set *__restrict __writefds,
     fd_set *__restrict __exceptfds,
     struct timeval *__restrict __timeout);
extern int pselect (int __nfds, fd_set *__restrict __readfds,
      fd_set *__restrict __writefds,
      fd_set *__restrict __exceptfds,
      const struct timespec *__restrict __timeout,
      const __sigset_t *__restrict __sigmask);
__extension__
extern unsigned int gnu_dev_major (unsigned long long int __dev)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
__extension__
extern unsigned int gnu_dev_minor (unsigned long long int __dev)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
__extension__
extern unsigned long long int gnu_dev_makedev (unsigned int __major,
            unsigned int __minor)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
typedef __blksize_t blksize_t;
typedef __blkcnt64_t blkcnt_t;
typedef __fsblkcnt64_t fsblkcnt_t;
typedef __fsfilcnt64_t fsfilcnt_t;
typedef unsigned long int pthread_t;
union pthread_attr_t
{
  char __size[56];
  long int __align;
};
typedef union pthread_attr_t pthread_attr_t;
typedef struct __pthread_internal_list
{
  struct __pthread_internal_list *__prev;
  struct __pthread_internal_list *__next;
} __pthread_list_t;
typedef union
{
  struct __pthread_mutex_s
  {
    int __lock;
    unsigned int __count;
    int __owner;
    unsigned int __nusers;
    int __kind;
    short __spins;
    short __elision;
    __pthread_list_t __list;
  } __data;
  char __size[40];
  long int __align;
} pthread_mutex_t;
typedef union
{
  char __size[4];
  int __align;
} pthread_mutexattr_t;
typedef union
{
  struct
  {
    int __lock;
    unsigned int __futex;
    __extension__ unsigned long long int __total_seq;
    __extension__ unsigned long long int __wakeup_seq;
    __extension__ unsigned long long int __woken_seq;
    void *__mutex;
    unsigned int __nwaiters;
    unsigned int __broadcast_seq;
  } __data;
  char __size[48];
  __extension__ long long int __align;
} pthread_cond_t;
typedef union
{
  char __size[4];
  int __align;
} pthread_condattr_t;
typedef unsigned int pthread_key_t;
typedef int pthread_once_t;
typedef union
{
  struct
  {
    int __lock;
    unsigned int __nr_readers;
    unsigned int __readers_wakeup;
    unsigned int __writer_wakeup;
    unsigned int __nr_readers_queued;
    unsigned int __nr_writers_queued;
    int __writer;
    int __shared;
    unsigned long int __pad1;
    unsigned long int __pad2;
    unsigned int __flags;
  } __data;
  char __size[56];
  long int __align;
} pthread_rwlock_t;
typedef union
{
  char __size[8];
  long int __align;
} pthread_rwlockattr_t;
typedef volatile int pthread_spinlock_t;
typedef union
{
  char __size[32];
  long int __align;
} pthread_barrier_t;
typedef union
{
  char __size[4];
  int __align;
} pthread_barrierattr_t;
extern long int random (void) __attribute__ ((__nothrow__ , __leaf__));
extern void srandom (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
extern char *initstate (unsigned int __seed, char *__statebuf,
   size_t __statelen) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
extern char *setstate (char *__statebuf) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
struct random_data
  {
    int32_t *fptr;
    int32_t *rptr;
    int32_t *state;
    int rand_type;
    int rand_deg;
    int rand_sep;
    int32_t *end_ptr;
  };
extern int random_r (struct random_data *__restrict __buf,
       int32_t *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int srandom_r (unsigned int __seed, struct random_data *__buf)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
extern int initstate_r (unsigned int __seed, char *__restrict __statebuf,
   size_t __statelen,
   struct random_data *__restrict __buf)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
extern int setstate_r (char *__restrict __statebuf,
         struct random_data *__restrict __buf)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int rand (void) __attribute__ ((__nothrow__ , __leaf__));
extern void srand (unsigned int __seed) __attribute__ ((__nothrow__ , __leaf__));
extern int rand_r (unsigned int *__seed) __attribute__ ((__nothrow__ , __leaf__));
extern double drand48 (void) __attribute__ ((__nothrow__ , __leaf__));
extern double erand48 (unsigned short int __xsubi[3]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern long int lrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
extern long int nrand48 (unsigned short int __xsubi[3])
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern long int mrand48 (void) __attribute__ ((__nothrow__ , __leaf__));
extern long int jrand48 (unsigned short int __xsubi[3])
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern void srand48 (long int __seedval) __attribute__ ((__nothrow__ , __leaf__));
extern unsigned short int *seed48 (unsigned short int __seed16v[3])
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern void lcong48 (unsigned short int __param[7]) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
struct drand48_data
  {
    unsigned short int __x[3];
    unsigned short int __old_x[3];
    unsigned short int __c;
    unsigned short int __init;
    unsigned long long int __a;
  };
extern int drand48_r (struct drand48_data *__restrict __buffer,
        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int erand48_r (unsigned short int __xsubi[3],
        struct drand48_data *__restrict __buffer,
        double *__restrict __result) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int lrand48_r (struct drand48_data *__restrict __buffer,
        long int *__restrict __result)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int nrand48_r (unsigned short int __xsubi[3],
        struct drand48_data *__restrict __buffer,
        long int *__restrict __result)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int mrand48_r (struct drand48_data *__restrict __buffer,
        long int *__restrict __result)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int jrand48_r (unsigned short int __xsubi[3],
        struct drand48_data *__restrict __buffer,
        long int *__restrict __result)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int srand48_r (long int __seedval, struct drand48_data *__buffer)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
extern int seed48_r (unsigned short int __seed16v[3],
       struct drand48_data *__buffer) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int lcong48_r (unsigned short int __param[7],
        struct drand48_data *__buffer)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
extern void *calloc (size_t __nmemb, size_t __size)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
extern void *realloc (void *__ptr, size_t __size)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__warn_unused_result__));
extern void free (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
extern void cfree (void *__ptr) __attribute__ ((__nothrow__ , __leaf__));
extern void *alloca (size_t __size) __attribute__ ((__nothrow__ , __leaf__));
extern void *valloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
extern void *aligned_alloc (size_t __alignment, size_t __size)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__, __alloc_size__ (2)));
extern void abort (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
extern int atexit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int at_quick_exit (void (*__func) (void)) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern void exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
extern void quick_exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
extern void _Exit (int __status) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__noreturn__));
extern char *getenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
extern int putenv (char *__string) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int setenv (const char *__name, const char *__value, int __replace)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
extern int unsetenv (const char *__name) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int clearenv (void) __attribute__ ((__nothrow__ , __leaf__));
extern char *mktemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int mkstemp (char *__template) __asm__ ("" "mkstemp64")
     __attribute__ ((__nonnull__ (1))) ;
extern int mkstemps (char *__template, int __suffixlen) __asm__ ("" "mkstemps64") __attribute__ ((__nonnull__ (1))) ;
extern char *mkdtemp (char *__template) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
extern int system (const char *__command) ;
extern char *realpath (const char *__restrict __name,
         char *__restrict __resolved) __attribute__ ((__nothrow__ , __leaf__)) ;
typedef int (*__compar_fn_t) (const void *, const void *);
extern void *bsearch (const void *__key, const void *__base,
        size_t __nmemb, size_t __size, __compar_fn_t __compar)
     __attribute__ ((__nonnull__ (1, 2, 5))) ;
extern void qsort (void *__base, size_t __nmemb, size_t __size,
     __compar_fn_t __compar) __attribute__ ((__nonnull__ (1, 4)));
extern int abs (int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
extern long int labs (long int __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
__extension__ extern long long int llabs (long long int __x)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
extern div_t div (int __numer, int __denom)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
extern ldiv_t ldiv (long int __numer, long int __denom)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
__extension__ extern lldiv_t lldiv (long long int __numer,
        long long int __denom)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)) ;
extern char *ecvt (double __value, int __ndigit, int *__restrict __decpt,
     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
extern char *fcvt (double __value, int __ndigit, int *__restrict __decpt,
     int *__restrict __sign) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
extern char *gcvt (double __value, int __ndigit, char *__buf)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
extern char *qecvt (long double __value, int __ndigit,
      int *__restrict __decpt, int *__restrict __sign)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
extern char *qfcvt (long double __value, int __ndigit,
      int *__restrict __decpt, int *__restrict __sign)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4))) ;
extern char *qgcvt (long double __value, int __ndigit, char *__buf)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3))) ;
extern int ecvt_r (double __value, int __ndigit, int *__restrict __decpt,
     int *__restrict __sign, char *__restrict __buf,
     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
extern int fcvt_r (double __value, int __ndigit, int *__restrict __decpt,
     int *__restrict __sign, char *__restrict __buf,
     size_t __len) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
extern int qecvt_r (long double __value, int __ndigit,
      int *__restrict __decpt, int *__restrict __sign,
      char *__restrict __buf, size_t __len)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
extern int qfcvt_r (long double __value, int __ndigit,
      int *__restrict __decpt, int *__restrict __sign,
      char *__restrict __buf, size_t __len)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (3, 4, 5)));
extern int mblen (const char *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) ;
extern int mbtowc (wchar_t *__restrict __pwc,
     const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) ;
extern int wctomb (char *__s, wchar_t __wchar) __attribute__ ((__nothrow__ , __leaf__)) ;
extern size_t mbstowcs (wchar_t *__restrict __pwcs,
   const char *__restrict __s, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
extern size_t wcstombs (char *__restrict __s,
   const wchar_t *__restrict __pwcs, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__));
extern int rpmatch (const char *__response) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1))) ;
extern int getsubopt (char **__restrict __optionp,
        char *const *__restrict __tokens,
        char **__restrict __valuep)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2, 3))) ;
extern int getloadavg (double __loadavg[], int __nelem)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
struct timezone
  {
    int tz_minuteswest;
    int tz_dsttime;
  };
typedef struct timezone *__restrict __timezone_ptr_t;
extern int gettimeofday (struct timeval *__restrict __tv,
    __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int settimeofday (const struct timeval *__tv,
    const struct timezone *__tz)
     __attribute__ ((__nothrow__ , __leaf__));
extern int adjtime (const struct timeval *__delta,
      struct timeval *__olddelta) __attribute__ ((__nothrow__ , __leaf__));
enum __itimer_which
  {
    ITIMER_REAL = 0,
    ITIMER_VIRTUAL = 1,
    ITIMER_PROF = 2
  };
struct itimerval
  {
    struct timeval it_interval;
    struct timeval it_value;
  };
typedef int __itimer_which_t;
extern int getitimer (__itimer_which_t __which,
        struct itimerval *__value) __attribute__ ((__nothrow__ , __leaf__));
extern int setitimer (__itimer_which_t __which,
        const struct itimerval *__restrict __new,
        struct itimerval *__restrict __old) __attribute__ ((__nothrow__ , __leaf__));
extern int utimes (const char *__file, const struct timeval __tvp[2])
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int lutimes (const char *__file, const struct timeval __tvp[2])
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int futimes (int __fd, const struct timeval __tvp[2]) __attribute__ ((__nothrow__ , __leaf__));
extern int __sigismember (const __sigset_t *, int);
extern int __sigaddset (__sigset_t *, int);
extern int __sigdelset (__sigset_t *, int);
typedef __sig_atomic_t sig_atomic_t;
typedef union sigval
  {
    int sival_int;
    void *sival_ptr;
  } sigval_t;
typedef __clock_t __sigchld_clock_t;
typedef struct
  {
    int si_signo;
    int si_errno;
    int si_code;
    union
      {
 int _pad[((128 / sizeof (int)) - 4)];
 struct
   {
     __pid_t si_pid;
     __uid_t si_uid;
   } _kill;
 struct
   {
     int si_tid;
     int si_overrun;
     sigval_t si_sigval;
   } _timer;
 struct
   {
     __pid_t si_pid;
     __uid_t si_uid;
     sigval_t si_sigval;
   } _rt;
 struct
   {
     __pid_t si_pid;
     __uid_t si_uid;
     int si_status;
     __sigchld_clock_t si_utime;
     __sigchld_clock_t si_stime;
   } _sigchld;
 struct
   {
     void *si_addr;
   } _sigfault;
 struct
   {
     long int si_band;
     int si_fd;
   } _sigpoll;
 struct
   {
     void *_call_addr;
     int _syscall;
     unsigned int _arch;
   } _sigsys;
      } _sifields;
  } siginfo_t ;
enum
{
  SI_ASYNCNL = -60,
  SI_TKILL = -6,
  SI_SIGIO,
  SI_ASYNCIO,
  SI_MESGQ,
  SI_TIMER,
  SI_QUEUE,
  SI_USER,
  SI_KERNEL = 0x80
};
enum
{
  ILL_ILLOPC = 1,
  ILL_ILLOPN,
  ILL_ILLADR,
  ILL_ILLTRP,
  ILL_PRVOPC,
  ILL_PRVREG,
  ILL_COPROC,
  ILL_BADSTK
};
enum
{
  FPE_INTDIV = 1,
  FPE_INTOVF,
  FPE_FLTDIV,
  FPE_FLTOVF,
  FPE_FLTUND,
  FPE_FLTRES,
  FPE_FLTINV,
  FPE_FLTSUB
};
enum
{
  SEGV_MAPERR = 1,
  SEGV_ACCERR
};
enum
{
  BUS_ADRALN = 1,
  BUS_ADRERR,
  BUS_OBJERR
};
enum
{
  TRAP_BRKPT = 1,
  TRAP_TRACE
};
enum
{
  CLD_EXITED = 1,
  CLD_KILLED,
  CLD_DUMPED,
  CLD_TRAPPED,
  CLD_STOPPED,
  CLD_CONTINUED
};
enum
{
  POLL_IN = 1,
  POLL_OUT,
  POLL_MSG,
  POLL_ERR,
  POLL_PRI,
  POLL_HUP
};
typedef struct sigevent
  {
    sigval_t sigev_value;
    int sigev_signo;
    int sigev_notify;
    union
      {
 int _pad[((64 / sizeof (int)) - 4)];
 __pid_t _tid;
 struct
   {
     void (*_function) (sigval_t);
     pthread_attr_t *_attribute;
   } _sigev_thread;
      } _sigev_un;
  } sigevent_t;
enum
{
  SIGEV_SIGNAL = 0,
  SIGEV_NONE,
  SIGEV_THREAD,
  SIGEV_THREAD_ID = 4
};
typedef void (*__sighandler_t) (int);
extern __sighandler_t __sysv_signal (int __sig, __sighandler_t __handler)
     __attribute__ ((__nothrow__ , __leaf__));
extern __sighandler_t signal (int __sig, __sighandler_t __handler)
     __attribute__ ((__nothrow__ , __leaf__));
extern int kill (__pid_t __pid, int __sig) __attribute__ ((__nothrow__ , __leaf__));
extern int killpg (__pid_t __pgrp, int __sig) __attribute__ ((__nothrow__ , __leaf__));
extern int raise (int __sig) __attribute__ ((__nothrow__ , __leaf__));
extern __sighandler_t ssignal (int __sig, __sighandler_t __handler)
     __attribute__ ((__nothrow__ , __leaf__));
extern int gsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
extern void psignal (int __sig, const char *__s);
extern void psiginfo (const siginfo_t *__pinfo, const char *__s);
extern int __sigpause (int __sig_or_mask, int __is_sig);
extern int sigblock (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
extern int sigsetmask (int __mask) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
extern int siggetmask (void) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
typedef __sighandler_t sig_t;
extern int sigemptyset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int sigfillset (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int sigaddset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int sigdelset (sigset_t *__set, int __signo) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int sigismember (const sigset_t *__set, int __signo)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
struct sigaction
  {
    union
      {
 __sighandler_t sa_handler;
 void (*sa_sigaction) (int, siginfo_t *, void *);
      }
    __sigaction_handler;
    __sigset_t sa_mask;
    int sa_flags;
    void (*sa_restorer) (void);
  };
extern int sigprocmask (int __how, const sigset_t *__restrict __set,
   sigset_t *__restrict __oset) __attribute__ ((__nothrow__ , __leaf__));
extern int sigsuspend (const sigset_t *__set) __attribute__ ((__nonnull__ (1)));
extern int sigaction (int __sig, const struct sigaction *__restrict __act,
        struct sigaction *__restrict __oact) __attribute__ ((__nothrow__ , __leaf__));
extern int sigpending (sigset_t *__set) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int sigwait (const sigset_t *__restrict __set, int *__restrict __sig)
     __attribute__ ((__nonnull__ (1, 2)));
extern int sigwaitinfo (const sigset_t *__restrict __set,
   siginfo_t *__restrict __info) __attribute__ ((__nonnull__ (1)));
extern int sigtimedwait (const sigset_t *__restrict __set,
    siginfo_t *__restrict __info,
    const struct timespec *__restrict __timeout)
     __attribute__ ((__nonnull__ (1)));
extern int sigqueue (__pid_t __pid, int __sig, const union sigval __val)
     __attribute__ ((__nothrow__ , __leaf__));
extern const char *const _sys_siglist[65];
extern const char *const sys_siglist[65];
struct sigvec
  {
    __sighandler_t sv_handler;
    int sv_mask;
    int sv_flags;
  };
extern int sigvec (int __sig, const struct sigvec *__vec,
     struct sigvec *__ovec) __attribute__ ((__nothrow__ , __leaf__));
struct _fpx_sw_bytes
{
  __uint32_t magic1;
  __uint32_t extended_size;
  __uint64_t xstate_bv;
  __uint32_t xstate_size;
  __uint32_t padding[7];
};
struct _fpreg
{
  unsigned short significand[4];
  unsigned short exponent;
};
struct _fpxreg
{
  unsigned short significand[4];
  unsigned short exponent;
  unsigned short padding[3];
};
struct _xmmreg
{
  __uint32_t element[4];
};
struct _fpstate
{
  __uint16_t cwd;
  __uint16_t swd;
  __uint16_t ftw;
  __uint16_t fop;
  __uint64_t rip;
  __uint64_t rdp;
  __uint32_t mxcsr;
  __uint32_t mxcr_mask;
  struct _fpxreg _st[8];
  struct _xmmreg _xmm[16];
  __uint32_t padding[24];
};
struct sigcontext
{
  __uint64_t r8;
  __uint64_t r9;
  __uint64_t r10;
  __uint64_t r11;
  __uint64_t r12;
  __uint64_t r13;
  __uint64_t r14;
  __uint64_t r15;
  __uint64_t rdi;
  __uint64_t rsi;
  __uint64_t rbp;
  __uint64_t rbx;
  __uint64_t rdx;
  __uint64_t rax;
  __uint64_t rcx;
  __uint64_t rsp;
  __uint64_t rip;
  __uint64_t eflags;
  unsigned short cs;
  unsigned short gs;
  unsigned short fs;
  unsigned short __pad0;
  __uint64_t err;
  __uint64_t trapno;
  __uint64_t oldmask;
  __uint64_t cr2;
  __extension__ union
    {
      struct _fpstate * fpstate;
      __uint64_t __fpstate_word;
    };
  __uint64_t __reserved1 [8];
};
struct _xsave_hdr
{
  __uint64_t xstate_bv;
  __uint64_t reserved1[2];
  __uint64_t reserved2[5];
};
struct _ymmh_state
{
  __uint32_t ymmh_space[64];
};
struct _xstate
{
  struct _fpstate fpstate;
  struct _xsave_hdr xstate_hdr;
  struct _ymmh_state ymmh;
};
extern int sigreturn (struct sigcontext *__scp) __attribute__ ((__nothrow__ , __leaf__));
extern int siginterrupt (int __sig, int __interrupt) __attribute__ ((__nothrow__ , __leaf__));
struct sigstack
  {
    void *ss_sp;
    int ss_onstack;
  };
enum
{
  SS_ONSTACK = 1,
  SS_DISABLE
};
typedef struct sigaltstack
  {
    void *ss_sp;
    int ss_flags;
    size_t ss_size;
  } stack_t;
__extension__ typedef long long int greg_t;
typedef greg_t gregset_t[23];
struct _libc_fpxreg
{
  unsigned short int significand[4];
  unsigned short int exponent;
  unsigned short int padding[3];
};
struct _libc_xmmreg
{
  __uint32_t element[4];
};
struct _libc_fpstate
{
  __uint16_t cwd;
  __uint16_t swd;
  __uint16_t ftw;
  __uint16_t fop;
  __uint64_t rip;
  __uint64_t rdp;
  __uint32_t mxcsr;
  __uint32_t mxcr_mask;
  struct _libc_fpxreg _st[8];
  struct _libc_xmmreg _xmm[16];
  __uint32_t padding[24];
};
typedef struct _libc_fpstate *fpregset_t;
typedef struct
  {
    gregset_t gregs;
    fpregset_t fpregs;
    __extension__ unsigned long long __reserved1 [8];
} mcontext_t;
typedef struct ucontext
  {
    unsigned long int uc_flags;
    struct ucontext *uc_link;
    stack_t uc_stack;
    mcontext_t uc_mcontext;
    __sigset_t uc_sigmask;
    struct _libc_fpstate __fpregs_mem;
  } ucontext_t;
extern int sigstack (struct sigstack *__ss, struct sigstack *__oss)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__deprecated__));
extern int sigaltstack (const struct sigaltstack *__restrict __ss,
   struct sigaltstack *__restrict __oss) __attribute__ ((__nothrow__ , __leaf__));
extern int pthread_sigmask (int __how,
       const __sigset_t *__restrict __newmask,
       __sigset_t *__restrict __oldmask)__attribute__ ((__nothrow__ , __leaf__));
extern int pthread_kill (pthread_t __threadid, int __signo) __attribute__ ((__nothrow__ , __leaf__));
extern int __libc_current_sigrtmin (void) __attribute__ ((__nothrow__ , __leaf__));
extern int __libc_current_sigrtmax (void) __attribute__ ((__nothrow__ , __leaf__));
typedef unsigned char uint8_t;
typedef unsigned short int uint16_t;
typedef unsigned int uint32_t;
typedef unsigned long int uint64_t;
typedef signed char int_least8_t;
typedef short int int_least16_t;
typedef int int_least32_t;
typedef long int int_least64_t;
typedef unsigned char uint_least8_t;
typedef unsigned short int uint_least16_t;
typedef unsigned int uint_least32_t;
typedef unsigned long int uint_least64_t;
typedef signed char int_fast8_t;
typedef long int int_fast16_t;
typedef long int int_fast32_t;
typedef long int int_fast64_t;
typedef unsigned char uint_fast8_t;
typedef unsigned long int uint_fast16_t;
typedef unsigned long int uint_fast32_t;
typedef unsigned long int uint_fast64_t;
typedef long int intptr_t;
typedef unsigned long int uintptr_t;
typedef long int intmax_t;
typedef unsigned long int uintmax_t;
struct iovec
  {
    void *iov_base;
    size_t iov_len;
  };
extern ssize_t readv (int __fd, const struct iovec *__iovec, int __count)
  ;
extern ssize_t writev (int __fd, const struct iovec *__iovec, int __count)
  ;
extern ssize_t preadv (int __fd, const struct iovec *__iovec, int __count, __off64_t __offset) __asm__ ("" "preadv64") ;
extern ssize_t pwritev (int __fd, const struct iovec *__iovec, int __count, __off64_t __offset) __asm__ ("" "pwritev64") ;
typedef __socklen_t socklen_t;
enum __socket_type
{
  SOCK_STREAM = 1,
  SOCK_DGRAM = 2,
  SOCK_RAW = 3,
  SOCK_RDM = 4,
  SOCK_SEQPACKET = 5,
  SOCK_DCCP = 6,
  SOCK_PACKET = 10,
  SOCK_CLOEXEC = 02000000,
  SOCK_NONBLOCK = 00004000
};
typedef unsigned short int sa_family_t;
struct sockaddr
  {
    sa_family_t sa_family;
    char sa_data[14];
  };
struct sockaddr_storage
  {
    sa_family_t ss_family;
    char __ss_padding[(128 - (sizeof (unsigned short int)) - sizeof (unsigned long int))];
    unsigned long int __ss_align;
  };
enum
  {
    MSG_OOB = 0x01,
    MSG_PEEK = 0x02,
    MSG_DONTROUTE = 0x04,
    MSG_CTRUNC = 0x08,
    MSG_PROXY = 0x10,
    MSG_TRUNC = 0x20,
    MSG_DONTWAIT = 0x40,
    MSG_EOR = 0x80,
    MSG_WAITALL = 0x100,
    MSG_FIN = 0x200,
    MSG_SYN = 0x400,
    MSG_CONFIRM = 0x800,
    MSG_RST = 0x1000,
    MSG_ERRQUEUE = 0x2000,
    MSG_NOSIGNAL = 0x4000,
    MSG_MORE = 0x8000,
    MSG_WAITFORONE = 0x10000,
    MSG_FASTOPEN = 0x20000000,
    MSG_CMSG_CLOEXEC = 0x40000000
  };
struct msghdr
  {
    void *msg_name;
    socklen_t msg_namelen;
    struct iovec *msg_iov;
    size_t msg_iovlen;
    void *msg_control;
    size_t msg_controllen;
    int msg_flags;
  };
struct cmsghdr
  {
    size_t cmsg_len;
    int cmsg_level;
    int cmsg_type;
    __extension__ unsigned char __cmsg_data [];
  };
extern struct cmsghdr *__cmsg_nxthdr (struct msghdr *__mhdr,
          struct cmsghdr *__cmsg) __attribute__ ((__nothrow__ , __leaf__));
enum
  {
    SCM_RIGHTS = 0x01
  };
struct linger
  {
    int l_onoff;
    int l_linger;
  };
struct osockaddr
  {
    unsigned short int sa_family;
    unsigned char sa_data[14];
  };
enum
{
  SHUT_RD = 0,
  SHUT_WR,
  SHUT_RDWR
};
extern int socket (int __domain, int __type, int __protocol) __attribute__ ((__nothrow__ , __leaf__));
extern int socketpair (int __domain, int __type, int __protocol,
         int __fds[2]) __attribute__ ((__nothrow__ , __leaf__));
extern int bind (int __fd, const struct sockaddr * __addr, socklen_t __len)
     __attribute__ ((__nothrow__ , __leaf__));
extern int getsockname (int __fd, struct sockaddr *__restrict __addr,
   socklen_t *__restrict __len) __attribute__ ((__nothrow__ , __leaf__));
extern int connect (int __fd, const struct sockaddr * __addr, socklen_t __len);
extern int getpeername (int __fd, struct sockaddr *__restrict __addr,
   socklen_t *__restrict __len) __attribute__ ((__nothrow__ , __leaf__));
extern ssize_t send (int __fd, const void *__buf, size_t __n, int __flags);
extern ssize_t recv (int __fd, void *__buf, size_t __n, int __flags);
extern ssize_t sendto (int __fd, const void *__buf, size_t __n,
         int __flags, const struct sockaddr * __addr,
         socklen_t __addr_len);
extern ssize_t recvfrom (int __fd, void *__restrict __buf, size_t __n,
    int __flags, struct sockaddr *__restrict __addr,
    socklen_t *__restrict __addr_len);
extern ssize_t sendmsg (int __fd, const struct msghdr *__message,
   int __flags);
extern ssize_t recvmsg (int __fd, struct msghdr *__message, int __flags);
extern int getsockopt (int __fd, int __level, int __optname,
         void *__restrict __optval,
         socklen_t *__restrict __optlen) __attribute__ ((__nothrow__ , __leaf__));
extern int setsockopt (int __fd, int __level, int __optname,
         const void *__optval, socklen_t __optlen) __attribute__ ((__nothrow__ , __leaf__));
extern int listen (int __fd, int __n) __attribute__ ((__nothrow__ , __leaf__));
extern int accept (int __fd, struct sockaddr *__restrict __addr,
     socklen_t *__restrict __addr_len);
extern int shutdown (int __fd, int __how) __attribute__ ((__nothrow__ , __leaf__));
extern int sockatmark (int __fd) __attribute__ ((__nothrow__ , __leaf__));
extern int isfdtype (int __fd, int __fdtype) __attribute__ ((__nothrow__ , __leaf__));
typedef uint32_t in_addr_t;
struct in_addr
  {
    in_addr_t s_addr;
  };
struct ip_opts
  {
    struct in_addr ip_dst;
    char ip_opts[40];
  };
struct ip_mreqn
  {
    struct in_addr imr_multiaddr;
    struct in_addr imr_address;
    int imr_ifindex;
  };
struct in_pktinfo
  {
    int ipi_ifindex;
    struct in_addr ipi_spec_dst;
    struct in_addr ipi_addr;
  };
enum
  {
    IPPROTO_IP = 0,
    IPPROTO_ICMP = 1,
    IPPROTO_IGMP = 2,
    IPPROTO_IPIP = 4,
    IPPROTO_TCP = 6,
    IPPROTO_EGP = 8,
    IPPROTO_PUP = 12,
    IPPROTO_UDP = 17,
    IPPROTO_IDP = 22,
    IPPROTO_TP = 29,
    IPPROTO_DCCP = 33,
    IPPROTO_IPV6 = 41,
    IPPROTO_RSVP = 46,
    IPPROTO_GRE = 47,
    IPPROTO_ESP = 50,
    IPPROTO_AH = 51,
    IPPROTO_MTP = 92,
    IPPROTO_BEETPH = 94,
    IPPROTO_ENCAP = 98,
    IPPROTO_PIM = 103,
    IPPROTO_COMP = 108,
    IPPROTO_SCTP = 132,
    IPPROTO_UDPLITE = 136,
    IPPROTO_MPLS = 137,
    IPPROTO_RAW = 255,
    IPPROTO_MAX
  };
enum
  {
    IPPROTO_HOPOPTS = 0,
    IPPROTO_ROUTING = 43,
    IPPROTO_FRAGMENT = 44,
    IPPROTO_ICMPV6 = 58,
    IPPROTO_NONE = 59,
    IPPROTO_DSTOPTS = 60,
    IPPROTO_MH = 135
  };
typedef uint16_t in_port_t;
enum
  {
    IPPORT_ECHO = 7,
    IPPORT_DISCARD = 9,
    IPPORT_SYSTAT = 11,
    IPPORT_DAYTIME = 13,
    IPPORT_NETSTAT = 15,
    IPPORT_FTP = 21,
    IPPORT_TELNET = 23,
    IPPORT_SMTP = 25,
    IPPORT_TIMESERVER = 37,
    IPPORT_NAMESERVER = 42,
    IPPORT_WHOIS = 43,
    IPPORT_MTP = 57,
    IPPORT_TFTP = 69,
    IPPORT_RJE = 77,
    IPPORT_FINGER = 79,
    IPPORT_TTYLINK = 87,
    IPPORT_SUPDUP = 95,
    IPPORT_EXECSERVER = 512,
    IPPORT_LOGINSERVER = 513,
    IPPORT_CMDSERVER = 514,
    IPPORT_EFSSERVER = 520,
    IPPORT_BIFFUDP = 512,
    IPPORT_WHOSERVER = 513,
    IPPORT_ROUTESERVER = 520,
    IPPORT_RESERVED = 1024,
    IPPORT_USERRESERVED = 5000
  };
struct in6_addr
  {
    union
      {
 uint8_t __u6_addr8[16];
 uint16_t __u6_addr16[8];
 uint32_t __u6_addr32[4];
      } __in6_u;
  };
extern const struct in6_addr in6addr_any;
extern const struct in6_addr in6addr_loopback;
struct sockaddr_in
  {
    sa_family_t sin_family;
    in_port_t sin_port;
    struct in_addr sin_addr;
    unsigned char sin_zero[sizeof (struct sockaddr) -
      (sizeof (unsigned short int)) -
      sizeof (in_port_t) -
      sizeof (struct in_addr)];
  };
struct sockaddr_in6
  {
    sa_family_t sin6_family;
    in_port_t sin6_port;
    uint32_t sin6_flowinfo;
    struct in6_addr sin6_addr;
    uint32_t sin6_scope_id;
  };
struct ip_mreq
  {
    struct in_addr imr_multiaddr;
    struct in_addr imr_interface;
  };
struct ip_mreq_source
  {
    struct in_addr imr_multiaddr;
    struct in_addr imr_interface;
    struct in_addr imr_sourceaddr;
  };
struct ipv6_mreq
  {
    struct in6_addr ipv6mr_multiaddr;
    unsigned int ipv6mr_interface;
  };
struct group_req
  {
    uint32_t gr_interface;
    struct sockaddr_storage gr_group;
  };
struct group_source_req
  {
    uint32_t gsr_interface;
    struct sockaddr_storage gsr_group;
    struct sockaddr_storage gsr_source;
  };
struct ip_msfilter
  {
    struct in_addr imsf_multiaddr;
    struct in_addr imsf_interface;
    uint32_t imsf_fmode;
    uint32_t imsf_numsrc;
    struct in_addr imsf_slist[1];
  };
struct group_filter
  {
    uint32_t gf_interface;
    struct sockaddr_storage gf_group;
    uint32_t gf_fmode;
    uint32_t gf_numsrc;
    struct sockaddr_storage gf_slist[1];
};
extern uint32_t ntohl (uint32_t __netlong) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
extern uint16_t ntohs (uint16_t __netshort)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
extern uint32_t htonl (uint32_t __hostlong)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
extern uint16_t htons (uint16_t __hostshort)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
extern int bindresvport (int __sockfd, struct sockaddr_in *__sock_in) __attribute__ ((__nothrow__ , __leaf__));
extern int bindresvport6 (int __sockfd, struct sockaddr_in6 *__sock_in)
     __attribute__ ((__nothrow__ , __leaf__));
struct _IO_FILE;
typedef struct _IO_FILE FILE;
typedef struct _IO_FILE __FILE;
typedef struct
{
  int __count;
  union
  {
    unsigned int __wch;
    char __wchb[4];
  } __value;
} __mbstate_t;
typedef struct
{
  __off_t __pos;
  __mbstate_t __state;
} _G_fpos_t;
typedef struct
{
  __off64_t __pos;
  __mbstate_t __state;
} _G_fpos64_t;
typedef __builtin_va_list __gnuc_va_list;
struct _IO_jump_t; struct _IO_FILE;
typedef void _IO_lock_t;
struct _IO_marker {
  struct _IO_marker *_next;
  struct _IO_FILE *_sbuf;
  int _pos;
};
enum __codecvt_result
{
  __codecvt_ok,
  __codecvt_partial,
  __codecvt_error,
  __codecvt_noconv
};
struct _IO_FILE {
  int _flags;
  char* _IO_read_ptr;
  char* _IO_read_end;
  char* _IO_read_base;
  char* _IO_write_base;
  char* _IO_write_ptr;
  char* _IO_write_end;
  char* _IO_buf_base;
  char* _IO_buf_end;
  char *_IO_save_base;
  char *_IO_backup_base;
  char *_IO_save_end;
  struct _IO_marker *_markers;
  struct _IO_FILE *_chain;
  int _fileno;
  int _flags2;
  __off_t _old_offset;
  unsigned short _cur_column;
  signed char _vtable_offset;
  char _shortbuf[1];
  _IO_lock_t *_lock;
  __off64_t _offset;
  void *__pad1;
  void *__pad2;
  void *__pad3;
  void *__pad4;
  size_t __pad5;
  int _mode;
  char _unused2[15 * sizeof (int) - 4 * sizeof (void *) - sizeof (size_t)];
};
typedef struct _IO_FILE _IO_FILE;
struct _IO_FILE_plus;
extern struct _IO_FILE_plus _IO_2_1_stdin_;
extern struct _IO_FILE_plus _IO_2_1_stdout_;
extern struct _IO_FILE_plus _IO_2_1_stderr_;
typedef __ssize_t __io_read_fn (void *__cookie, char *__buf, size_t __nbytes);
typedef __ssize_t __io_write_fn (void *__cookie, const char *__buf,
     size_t __n);
typedef int __io_seek_fn (void *__cookie, __off64_t *__pos, int __w);
typedef int __io_close_fn (void *__cookie);
extern int __underflow (_IO_FILE *);
extern int __uflow (_IO_FILE *);
extern int __overflow (_IO_FILE *, int);
extern int _IO_getc (_IO_FILE *__fp);
extern int _IO_putc (int __c, _IO_FILE *__fp);
extern int _IO_feof (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
extern int _IO_ferror (_IO_FILE *__fp) __attribute__ ((__nothrow__ , __leaf__));
extern int _IO_peekc_locked (_IO_FILE *__fp);
extern void _IO_flockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
extern void _IO_funlockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
extern int _IO_ftrylockfile (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
extern int _IO_vfscanf (_IO_FILE * __restrict, const char * __restrict,
   __gnuc_va_list, int *__restrict);
extern int _IO_vfprintf (_IO_FILE *__restrict, const char *__restrict,
    __gnuc_va_list);
extern __ssize_t _IO_padn (_IO_FILE *, int, __ssize_t);
extern size_t _IO_sgetn (_IO_FILE *, void *, size_t);
extern __off64_t _IO_seekoff (_IO_FILE *, __off64_t, int, int);
extern __off64_t _IO_seekpos (_IO_FILE *, __off64_t, int);
extern void _IO_free_backup_area (_IO_FILE *) __attribute__ ((__nothrow__ , __leaf__));
typedef __gnuc_va_list va_list;
typedef _G_fpos64_t fpos_t;
extern struct _IO_FILE *stdin;
extern struct _IO_FILE *stdout;
extern struct _IO_FILE *stderr;
extern int remove (const char *__filename) __attribute__ ((__nothrow__ , __leaf__));
extern int rename (const char *__old, const char *__new) __attribute__ ((__nothrow__ , __leaf__));
extern int renameat (int __oldfd, const char *__old, int __newfd,
       const char *__new) __attribute__ ((__nothrow__ , __leaf__));
extern FILE *tmpfile (void) __asm__ ("" "tmpfile64") ;
extern char *tmpnam (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
extern char *tmpnam_r (char *__s) __attribute__ ((__nothrow__ , __leaf__)) ;
extern char *tempnam (const char *__dir, const char *__pfx)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
extern int fclose (FILE *__stream);
extern int fflush (FILE *__stream);
extern int fflush_unlocked (FILE *__stream);
extern FILE *fopen (const char *__restrict __filename, const char *__restrict __modes) __asm__ ("" "fopen64")
  ;
extern FILE *freopen (const char *__restrict __filename, const char *__restrict __modes, FILE *__restrict __stream) __asm__ ("" "freopen64")
  ;
extern FILE *fdopen (int __fd, const char *__modes) __attribute__ ((__nothrow__ , __leaf__)) ;
extern FILE *fmemopen (void *__s, size_t __len, const char *__modes)
  __attribute__ ((__nothrow__ , __leaf__)) ;
extern FILE *open_memstream (char **__bufloc, size_t *__sizeloc) __attribute__ ((__nothrow__ , __leaf__)) ;
extern void setbuf (FILE *__restrict __stream, char *__restrict __buf) __attribute__ ((__nothrow__ , __leaf__));
extern int setvbuf (FILE *__restrict __stream, char *__restrict __buf,
      int __modes, size_t __n) __attribute__ ((__nothrow__ , __leaf__));
extern void setbuffer (FILE *__restrict __stream, char *__restrict __buf,
         size_t __size) __attribute__ ((__nothrow__ , __leaf__));
extern void setlinebuf (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
extern int fprintf (FILE *__restrict __stream,
      const char *__restrict __format, ...);
extern int printf (const char *__restrict __format, ...);
extern int sprintf (char *__restrict __s,
      const char *__restrict __format, ...) __attribute__ ((__nothrow__));
extern int vfprintf (FILE *__restrict __s, const char *__restrict __format,
       __gnuc_va_list __arg);
extern int vprintf (const char *__restrict __format, __gnuc_va_list __arg);
extern int vsprintf (char *__restrict __s, const char *__restrict __format,
       __gnuc_va_list __arg) __attribute__ ((__nothrow__));
extern int snprintf (char *__restrict __s, size_t __maxlen,
       const char *__restrict __format, ...)
     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 4)));
extern int vsnprintf (char *__restrict __s, size_t __maxlen,
        const char *__restrict __format, __gnuc_va_list __arg)
     __attribute__ ((__nothrow__)) __attribute__ ((__format__ (__printf__, 3, 0)));
extern int vdprintf (int __fd, const char *__restrict __fmt,
       __gnuc_va_list __arg)
     __attribute__ ((__format__ (__printf__, 2, 0)));
extern int dprintf (int __fd, const char *__restrict __fmt, ...)
     __attribute__ ((__format__ (__printf__, 2, 3)));
extern int fscanf (FILE *__restrict __stream,
     const char *__restrict __format, ...) ;
extern int scanf (const char *__restrict __format, ...) ;
extern int sscanf (const char *__restrict __s,
     const char *__restrict __format, ...) __attribute__ ((__nothrow__ , __leaf__));
extern int fscanf (FILE *__restrict __stream, const char *__restrict __format, ...) __asm__ ("" "__isoc99_fscanf") ;
extern int scanf (const char *__restrict __format, ...) __asm__ ("" "__isoc99_scanf") ;
extern int sscanf (const char *__restrict __s, const char *__restrict __format, ...) __asm__ ("" "__isoc99_sscanf") __attribute__ ((__nothrow__ , __leaf__));
extern int vfscanf (FILE *__restrict __s, const char *__restrict __format,
      __gnuc_va_list __arg)
     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg)
     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
extern int vsscanf (const char *__restrict __s,
      const char *__restrict __format, __gnuc_va_list __arg)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__format__ (__scanf__, 2, 0)));
extern int vfscanf (FILE *__restrict __s, const char *__restrict __format, __gnuc_va_list __arg) __asm__ ("" "__isoc99_vfscanf")
     __attribute__ ((__format__ (__scanf__, 2, 0))) ;
extern int vscanf (const char *__restrict __format, __gnuc_va_list __arg) __asm__ ("" "__isoc99_vscanf")
     __attribute__ ((__format__ (__scanf__, 1, 0))) ;
extern int vsscanf (const char *__restrict __s, const char *__restrict __format, __gnuc_va_list __arg) __asm__ ("" "__isoc99_vsscanf") __attribute__ ((__nothrow__ , __leaf__))
     __attribute__ ((__format__ (__scanf__, 2, 0)));
extern int fgetc (FILE *__stream);
extern int getc (FILE *__stream);
extern int getchar (void);
extern int getc_unlocked (FILE *__stream);
extern int getchar_unlocked (void);
extern int fgetc_unlocked (FILE *__stream);
extern int fputc (int __c, FILE *__stream);
extern int putc (int __c, FILE *__stream);
extern int putchar (int __c);
extern int fputc_unlocked (int __c, FILE *__stream);
extern int putc_unlocked (int __c, FILE *__stream);
extern int putchar_unlocked (int __c);
extern int getw (FILE *__stream);
extern int putw (int __w, FILE *__stream);
extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
     ;
extern __ssize_t __getdelim (char **__restrict __lineptr,
          size_t *__restrict __n, int __delimiter,
          FILE *__restrict __stream) ;
extern __ssize_t getdelim (char **__restrict __lineptr,
        size_t *__restrict __n, int __delimiter,
        FILE *__restrict __stream) ;
extern __ssize_t getline (char **__restrict __lineptr,
       size_t *__restrict __n,
       FILE *__restrict __stream) ;
extern int fputs (const char *__restrict __s, FILE *__restrict __stream);
extern int puts (const char *__s);
extern int ungetc (int __c, FILE *__stream);
extern size_t fread (void *__restrict __ptr, size_t __size,
       size_t __n, FILE *__restrict __stream) ;
extern size_t fwrite (const void *__restrict __ptr, size_t __size,
        size_t __n, FILE *__restrict __s);
extern size_t fread_unlocked (void *__restrict __ptr, size_t __size,
         size_t __n, FILE *__restrict __stream) ;
extern size_t fwrite_unlocked (const void *__restrict __ptr, size_t __size,
          size_t __n, FILE *__restrict __stream);
extern int fseek (FILE *__stream, long int __off, int __whence);
extern long int ftell (FILE *__stream) ;
extern void rewind (FILE *__stream);
extern int fseeko (FILE *__stream, __off64_t __off, int __whence) __asm__ ("" "fseeko64");
extern __off64_t ftello (FILE *__stream) __asm__ ("" "ftello64");
extern int fgetpos (FILE *__restrict __stream, fpos_t *__restrict __pos) __asm__ ("" "fgetpos64");
extern int fsetpos (FILE *__stream, const fpos_t *__pos) __asm__ ("" "fsetpos64");
extern void clearerr (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
extern int feof (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
extern int ferror (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
extern void clearerr_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
extern int feof_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
extern int ferror_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
extern void perror (const char *__s);
extern int sys_nerr;
extern const char *const sys_errlist[];
extern int fileno (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
extern int fileno_unlocked (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
extern FILE *popen (const char *__command, const char *__modes) ;
extern int pclose (FILE *__stream);
extern char *ctermid (char *__s) __attribute__ ((__nothrow__ , __leaf__));
extern void flockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
extern int ftrylockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__)) ;
extern void funlockfile (FILE *__stream) __attribute__ ((__nothrow__ , __leaf__));
enum xdr_op {
  XDR_ENCODE = 0,
  XDR_DECODE = 1,
  XDR_FREE = 2
};
typedef struct XDR XDR;
struct XDR
  {
    enum xdr_op x_op;
    struct xdr_ops
      {
 bool_t (*x_getlong) (XDR *__xdrs, long *__lp);
 bool_t (*x_putlong) (XDR *__xdrs, const long *__lp);
 bool_t (*x_getbytes) (XDR *__xdrs, caddr_t __addr, u_int __len);
 bool_t (*x_putbytes) (XDR *__xdrs, const char *__addr, u_int __len);
 u_int (*x_getpostn) (const XDR *__xdrs);
 bool_t (*x_setpostn) (XDR *__xdrs, u_int __pos);
 int32_t *(*x_inline) (XDR *__xdrs, u_int __len);
 void (*x_destroy) (XDR *__xdrs);
 bool_t (*x_getint32) (XDR *__xdrs, int32_t *__ip);
 bool_t (*x_putint32) (XDR *__xdrs, const int32_t *__ip);
      }
     *x_ops;
    caddr_t x_public;
    caddr_t x_private;
    caddr_t x_base;
    u_int x_handy;
  };
typedef bool_t (*xdrproc_t) (XDR *, void *,...);
struct xdr_discrim
{
  int value;
  xdrproc_t proc;
};
extern bool_t xdr_void (void) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_short (XDR *__xdrs, short *__sp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_u_short (XDR *__xdrs, u_short *__usp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_int (XDR *__xdrs, int *__ip) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_u_int (XDR *__xdrs, u_int *__up) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_long (XDR *__xdrs, long *__lp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_u_long (XDR *__xdrs, u_long *__ulp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_hyper (XDR *__xdrs, quad_t *__llp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_u_hyper (XDR *__xdrs, u_quad_t *__ullp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_longlong_t (XDR *__xdrs, quad_t *__llp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_u_longlong_t (XDR *__xdrs, u_quad_t *__ullp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_int8_t (XDR *__xdrs, int8_t *__ip) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_uint8_t (XDR *__xdrs, uint8_t *__up) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_int16_t (XDR *__xdrs, int16_t *__ip) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_uint16_t (XDR *__xdrs, uint16_t *__up) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_int32_t (XDR *__xdrs, int32_t *__ip) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_uint32_t (XDR *__xdrs, uint32_t *__up) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_int64_t (XDR *__xdrs, int64_t *__ip) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_uint64_t (XDR *__xdrs, uint64_t *__up) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_quad_t (XDR *__xdrs, quad_t *__ip) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_u_quad_t (XDR *__xdrs, u_quad_t *__up) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_bool (XDR *__xdrs, bool_t *__bp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_enum (XDR *__xdrs, enum_t *__ep) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_array (XDR * _xdrs, caddr_t *__addrp, u_int *__sizep,
    u_int __maxsize, u_int __elsize, xdrproc_t __elproc)
     __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_bytes (XDR *__xdrs, char **__cpp, u_int *__sizep,
    u_int __maxsize) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_opaque (XDR *__xdrs, caddr_t __cp, u_int __cnt) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_string (XDR *__xdrs, char **__cpp, u_int __maxsize) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_union (XDR *__xdrs, enum_t *__dscmp, char *__unp,
    const struct xdr_discrim *__choices,
    xdrproc_t __dfault) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_char (XDR *__xdrs, char *__cp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_u_char (XDR *__xdrs, u_char *__cp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_vector (XDR *__xdrs, char *__basep, u_int __nelem,
     u_int __elemsize, xdrproc_t __xdr_elem) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_float (XDR *__xdrs, float *__fp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_double (XDR *__xdrs, double *__dp) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_reference (XDR *__xdrs, caddr_t *__xpp, u_int __size,
        xdrproc_t __proc) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_pointer (XDR *__xdrs, char **__objpp,
      u_int __obj_size, xdrproc_t __xdr_obj) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_wrapstring (XDR *__xdrs, char **__cpp) __attribute__ ((__nothrow__ , __leaf__));
extern u_long xdr_sizeof (xdrproc_t, void *) __attribute__ ((__nothrow__ , __leaf__));
struct netobj
{
  u_int n_len;
  char *n_bytes;
};
typedef struct netobj netobj;
extern bool_t xdr_netobj (XDR *__xdrs, struct netobj *__np) __attribute__ ((__nothrow__ , __leaf__));
extern void xdrmem_create (XDR *__xdrs, const caddr_t __addr,
      u_int __size, enum xdr_op __xop) __attribute__ ((__nothrow__ , __leaf__));
extern void xdrstdio_create (XDR *__xdrs, FILE *__file, enum xdr_op __xop)
     __attribute__ ((__nothrow__ , __leaf__));
extern void xdrrec_create (XDR *__xdrs, u_int __sendsize,
      u_int __recvsize, caddr_t __tcp_handle,
      int (*__readit) (char *, char *, int),
      int (*__writeit) (char *, char *, int)) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdrrec_endofrecord (XDR *__xdrs, bool_t __sendnow) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdrrec_skiprecord (XDR *__xdrs) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdrrec_eof (XDR *__xdrs) __attribute__ ((__nothrow__ , __leaf__));
extern void xdr_free (xdrproc_t __proc, char *__objp) __attribute__ ((__nothrow__ , __leaf__));
enum auth_stat {
 AUTH_OK=0,
 AUTH_BADCRED=1,
 AUTH_REJECTEDCRED=2,
 AUTH_BADVERF=3,
 AUTH_REJECTEDVERF=4,
 AUTH_TOOWEAK=5,
 AUTH_INVALIDRESP=6,
 AUTH_FAILED=7
};
union des_block {
 struct {
  u_int32_t high;
  u_int32_t low;
 } key;
 char c[8];
};
typedef union des_block des_block;
extern bool_t xdr_des_block (XDR *__xdrs, des_block *__blkp) __attribute__ ((__nothrow__ , __leaf__));
struct opaque_auth {
 enum_t oa_flavor;
 caddr_t oa_base;
 u_int oa_length;
};
typedef struct AUTH AUTH;
struct AUTH {
  struct opaque_auth ah_cred;
  struct opaque_auth ah_verf;
  union des_block ah_key;
  struct auth_ops {
    void (*ah_nextverf) (AUTH *);
    int (*ah_marshal) (AUTH *, XDR *);
    int (*ah_validate) (AUTH *, struct opaque_auth *);
    int (*ah_refresh) (AUTH *);
    void (*ah_destroy) (AUTH *);
  } *ah_ops;
  caddr_t ah_private;
};
extern struct opaque_auth _null_auth;
extern AUTH *authunix_create (char *__machname, __uid_t __uid, __gid_t __gid,
         int __len, __gid_t *__aup_gids);
extern AUTH *authunix_create_default (void);
extern AUTH *authnone_create (void) __attribute__ ((__nothrow__ , __leaf__));
extern AUTH *authdes_create (const char *__servername, u_int __window,
        struct sockaddr *__syncaddr, des_block *__ckey)
     __attribute__ ((__nothrow__ , __leaf__));
extern AUTH *authdes_pk_create (const char *, netobj *, u_int,
    struct sockaddr *, des_block *) __attribute__ ((__nothrow__ , __leaf__));
extern int getnetname (char *) __attribute__ ((__nothrow__ , __leaf__));
extern int host2netname (char *, const char *, const char *) __attribute__ ((__nothrow__ , __leaf__));
extern int user2netname (char *, const uid_t, const char *) __attribute__ ((__nothrow__ , __leaf__));
extern int netname2user (const char *, uid_t *, gid_t *, int *, gid_t *)
     __attribute__ ((__nothrow__ , __leaf__));
extern int netname2host (const char *, char *, const int) __attribute__ ((__nothrow__ , __leaf__));
extern int key_decryptsession (char *, des_block *);
extern int key_decryptsession_pk (char *, netobj *, des_block *);
extern int key_encryptsession (char *, des_block *);
extern int key_encryptsession_pk (char *, netobj *, des_block *);
extern int key_gendes (des_block *);
extern int key_setsecret (char *);
extern int key_secretkey_is_set (void);
extern int key_get_conv (char *, des_block *);
extern bool_t xdr_opaque_auth (XDR *, struct opaque_auth *) __attribute__ ((__nothrow__ , __leaf__));
struct sockaddr_un
  {
    sa_family_t sun_family;
    char sun_path[108];
  };
extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
       size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern void *memmove (void *__dest, const void *__src, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern void *memccpy (void *__restrict __dest, const void *__restrict __src,
        int __c, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern void *memset (void *__s, int __c, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int memcmp (const void *__s1, const void *__s2, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern void *memchr (const void *__s, int __c, size_t __n)
      __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
extern char *strcpy (char *__restrict __dest, const char *__restrict __src)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strncpy (char *__restrict __dest,
        const char *__restrict __src, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strcat (char *__restrict __dest, const char *__restrict __src)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strncat (char *__restrict __dest, const char *__restrict __src,
        size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern int strcmp (const char *__s1, const char *__s2)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern int strncmp (const char *__s1, const char *__s2, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern int strcoll (const char *__s1, const char *__s2)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern size_t strxfrm (char *__restrict __dest,
         const char *__restrict __src, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
typedef struct __locale_struct
{
  struct __locale_data *__locales[13];
  const unsigned short int *__ctype_b;
  const int *__ctype_tolower;
  const int *__ctype_toupper;
  const char *__names[13];
} *__locale_t;
typedef __locale_t locale_t;
extern int strcoll_l (const char *__s1, const char *__s2, __locale_t __l)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2, 3)));
extern size_t strxfrm_l (char *__dest, const char *__src, size_t __n,
    __locale_t __l) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 4)));
extern char *strdup (const char *__s)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
extern char *strndup (const char *__string, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) __attribute__ ((__nonnull__ (1)));
extern char *strchr (const char *__s, int __c)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
extern char *strrchr (const char *__s, int __c)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
extern size_t strcspn (const char *__s, const char *__reject)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern size_t strspn (const char *__s, const char *__accept)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strpbrk (const char *__s, const char *__accept)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strstr (const char *__haystack, const char *__needle)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strtok (char *__restrict __s, const char *__restrict __delim)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
extern char *__strtok_r (char *__restrict __s,
    const char *__restrict __delim,
    char **__restrict __save_ptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
         char **__restrict __save_ptr)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2, 3)));
extern size_t strlen (const char *__s)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
extern size_t strnlen (const char *__string, size_t __maxlen)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
extern char *strerror (int __errnum) __attribute__ ((__nothrow__ , __leaf__));
extern int strerror_r (int __errnum, char *__buf, size_t __buflen) __asm__ ("" "__xpg_strerror_r") __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
extern char *strerror_l (int __errnum, __locale_t __l) __attribute__ ((__nothrow__ , __leaf__));
extern void __bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern void bcopy (const void *__src, void *__dest, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern void bzero (void *__s, size_t __n) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));
extern int bcmp (const void *__s1, const void *__s2, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *index (const char *__s, int __c)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
extern char *rindex (const char *__s, int __c)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1)));
extern int ffs (int __i) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
extern int strcasecmp (const char *__s1, const char *__s2)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern int strncasecmp (const char *__s1, const char *__s2, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__pure__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strsep (char **__restrict __stringp,
       const char *__restrict __delim)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *strsignal (int __sig) __attribute__ ((__nothrow__ , __leaf__));
extern char *__stpcpy (char *__restrict __dest, const char *__restrict __src)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *stpcpy (char *__restrict __dest, const char *__restrict __src)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *__stpncpy (char *__restrict __dest,
   const char *__restrict __src, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
extern char *stpncpy (char *__restrict __dest,
        const char *__restrict __src, size_t __n)
     __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1, 2)));
enum clnt_stat {
 RPC_SUCCESS=0,
 RPC_CANTENCODEARGS=1,
 RPC_CANTDECODERES=2,
 RPC_CANTSEND=3,
 RPC_CANTRECV=4,
 RPC_TIMEDOUT=5,
 RPC_VERSMISMATCH=6,
 RPC_AUTHERROR=7,
 RPC_PROGUNAVAIL=8,
 RPC_PROGVERSMISMATCH=9,
 RPC_PROCUNAVAIL=10,
 RPC_CANTDECODEARGS=11,
 RPC_SYSTEMERROR=12,
 RPC_NOBROADCAST = 21,
 RPC_UNKNOWNHOST=13,
 RPC_UNKNOWNPROTO=17,
 RPC_UNKNOWNADDR = 19,
 RPC_RPCBFAILURE=14,
 RPC_PROGNOTREGISTERED=15,
 RPC_N2AXLATEFAILURE = 22,
 RPC_FAILED=16,
 RPC_INTR=18,
 RPC_TLIERROR=20,
 RPC_UDERROR=23,
 RPC_INPROGRESS = 24,
 RPC_STALERACHANDLE = 25
};
struct rpc_err {
  enum clnt_stat re_status;
  union {
    int RE_errno;
    enum auth_stat RE_why;
    struct {
      u_long low;
      u_long high;
    } RE_vers;
    struct {
      long s1;
      long s2;
    } RE_lb;
  } ru;
};
typedef struct CLIENT CLIENT;
struct CLIENT {
  AUTH *cl_auth;
  struct clnt_ops {
    enum clnt_stat (*cl_call) (CLIENT *, u_long, xdrproc_t, caddr_t, xdrproc_t,
          caddr_t, struct timeval);
    void (*cl_abort) (void);
    void (*cl_geterr) (CLIENT *, struct rpc_err *);
    bool_t (*cl_freeres) (CLIENT *, xdrproc_t, caddr_t);
    void (*cl_destroy) (CLIENT *);
    bool_t (*cl_control) (CLIENT *, int, char *);
  } *cl_ops;
  caddr_t cl_private;
};
extern CLIENT *clntraw_create (const u_long __prog, const u_long __vers)
     __attribute__ ((__nothrow__ , __leaf__));
extern CLIENT *clnt_create (const char *__host, const u_long __prog,
       const u_long __vers, const char *__prot)
     __attribute__ ((__nothrow__ , __leaf__));
extern CLIENT *clnttcp_create (struct sockaddr_in *__raddr, u_long __prog,
          u_long __version, int *__sockp, u_int __sendsz,
          u_int __recvsz) __attribute__ ((__nothrow__ , __leaf__));
extern CLIENT *clntudp_create (struct sockaddr_in *__raddr, u_long __program,
          u_long __version, struct timeval __wait_resend,
          int *__sockp) __attribute__ ((__nothrow__ , __leaf__));
extern CLIENT *clntudp_bufcreate (struct sockaddr_in *__raddr,
      u_long __program, u_long __version,
      struct timeval __wait_resend, int *__sockp,
      u_int __sendsz, u_int __recvsz) __attribute__ ((__nothrow__ , __leaf__));
extern CLIENT *clntunix_create (struct sockaddr_un *__raddr, u_long __program,
     u_long __version, int *__sockp,
     u_int __sendsz, u_int __recvsz) __attribute__ ((__nothrow__ , __leaf__));
extern int callrpc (const char *__host, const u_long __prognum,
      const u_long __versnum, const u_long __procnum,
      const xdrproc_t __inproc, const char *__in,
      const xdrproc_t __outproc, char *__out) __attribute__ ((__nothrow__ , __leaf__));
extern int _rpc_dtablesize (void) __attribute__ ((__nothrow__ , __leaf__));
extern void clnt_pcreateerror (const char *__msg);
extern char *clnt_spcreateerror(const char *__msg) __attribute__ ((__nothrow__ , __leaf__));
extern void clnt_perrno (enum clnt_stat __num);
extern void clnt_perror (CLIENT *__clnt, const char *__msg);
extern char *clnt_sperror (CLIENT *__clnt, const char *__msg) __attribute__ ((__nothrow__ , __leaf__));
struct rpc_createerr {
 enum clnt_stat cf_stat;
 struct rpc_err cf_error;
};
extern struct rpc_createerr rpc_createerr;
extern char *clnt_sperrno (enum clnt_stat __num) __attribute__ ((__nothrow__ , __leaf__));
extern int getrpcport (const char * __host, u_long __prognum,
         u_long __versnum, u_int __proto) __attribute__ ((__nothrow__ , __leaf__));
extern void get_myaddress (struct sockaddr_in *) __attribute__ ((__nothrow__ , __leaf__));
enum msg_type {
 CALL=0,
 REPLY=1
};
enum reply_stat {
 MSG_ACCEPTED=0,
 MSG_DENIED=1
};
enum accept_stat {
 SUCCESS=0,
 PROG_UNAVAIL=1,
 PROG_MISMATCH=2,
 PROC_UNAVAIL=3,
 GARBAGE_ARGS=4,
 SYSTEM_ERR=5
};
enum reject_stat {
 RPC_MISMATCH=0,
 AUTH_ERROR=1
};
struct accepted_reply {
 struct opaque_auth ar_verf;
 enum accept_stat ar_stat;
 union {
  struct {
   u_long low;
   u_long high;
  } AR_versions;
  struct {
   caddr_t where;
   xdrproc_t proc;
  } AR_results;
 } ru;
};
struct rejected_reply {
 enum reject_stat rj_stat;
 union {
  struct {
   u_long low;
   u_long high;
  } RJ_versions;
  enum auth_stat RJ_why;
 } ru;
};
struct reply_body {
 enum reply_stat rp_stat;
 union {
  struct accepted_reply RP_ar;
  struct rejected_reply RP_dr;
 } ru;
};
struct call_body {
 u_long cb_rpcvers;
 u_long cb_prog;
 u_long cb_vers;
 u_long cb_proc;
 struct opaque_auth cb_cred;
 struct opaque_auth cb_verf;
};
struct rpc_msg {
 u_long rm_xid;
 enum msg_type rm_direction;
 union {
  struct call_body RM_cmb;
  struct reply_body RM_rmb;
 } ru;
};
extern bool_t xdr_callmsg (XDR *__xdrs, struct rpc_msg *__cmsg) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_callhdr (XDR *__xdrs, struct rpc_msg *__cmsg) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t xdr_replymsg (XDR *__xdrs, struct rpc_msg *__rmsg) __attribute__ ((__nothrow__ , __leaf__));
extern void _seterr_reply (struct rpc_msg *__msg, struct rpc_err *__error)
     __attribute__ ((__nothrow__ , __leaf__));
struct authunix_parms
  {
    u_long aup_time;
    char *aup_machname;
    __uid_t aup_uid;
    __gid_t aup_gid;
    u_int aup_len;
    __gid_t *aup_gids;
  };
extern bool_t xdr_authunix_parms (XDR *__xdrs, struct authunix_parms *__p)
     __attribute__ ((__nothrow__ , __leaf__));
struct short_hand_verf
  {
    struct opaque_auth new_cred;
  };
enum authdes_namekind
  {
    ADN_FULLNAME,
    ADN_NICKNAME
  };
struct authdes_fullname
  {
    char *name;
    des_block key;
    uint32_t window;
  };
struct authdes_cred
  {
    enum authdes_namekind adc_namekind;
    struct authdes_fullname adc_fullname;
    uint32_t adc_nickname;
  };
struct rpc_timeval
  {
    uint32_t tv_sec;
    uint32_t tv_usec;
  };
struct authdes_verf
  {
    union
      {
 struct rpc_timeval adv_ctime;
 des_block adv_xtime;
      }
    adv_time_u;
    uint32_t adv_int_u;
  };
extern int authdes_getucred (const struct authdes_cred * __adc,
        uid_t * __uid, gid_t * __gid,
        short *__grouplen, gid_t * __groups) __attribute__ ((__nothrow__ , __leaf__));
extern int getpublickey (const char *__name, char *__key) __attribute__ ((__nothrow__ , __leaf__));
extern int getsecretkey (const char *__name, char *__key,
    const char *__passwd) __attribute__ ((__nothrow__ , __leaf__));
extern int rtime (struct sockaddr_in *__addrp, struct rpc_timeval *__timep,
    struct rpc_timeval *__timeout) __attribute__ ((__nothrow__ , __leaf__));
enum xprt_stat {
 XPRT_DIED,
 XPRT_MOREREQS,
 XPRT_IDLE
};
typedef struct SVCXPRT SVCXPRT;
struct SVCXPRT {
  int xp_sock;
  u_short xp_port;
  const struct xp_ops {
    bool_t (*xp_recv) (SVCXPRT *__xprt, struct rpc_msg *__msg);
    enum xprt_stat (*xp_stat) (SVCXPRT *__xprt);
    bool_t (*xp_getargs) (SVCXPRT *__xprt, xdrproc_t __xdr_args,
          caddr_t __args_ptr);
    bool_t (*xp_reply) (SVCXPRT *__xprt, struct rpc_msg *__msg);
    bool_t (*xp_freeargs) (SVCXPRT *__xprt, xdrproc_t __xdr_args,
    caddr_t __args_ptr);
    void (*xp_destroy) (SVCXPRT *__xprt);
  } *xp_ops;
  int xp_addrlen;
  struct sockaddr_in xp_raddr;
  struct opaque_auth xp_verf;
  caddr_t xp_p1;
  caddr_t xp_p2;
  char xp_pad [256];
};
struct svc_req {
  rpcprog_t rq_prog;
  rpcvers_t rq_vers;
  rpcproc_t rq_proc;
  struct opaque_auth rq_cred;
  caddr_t rq_clntcred;
  SVCXPRT *rq_xprt;
};
typedef void (*__dispatch_fn_t) (struct svc_req*, SVCXPRT*);
extern bool_t svc_register (SVCXPRT *__xprt, rpcprog_t __prog,
       rpcvers_t __vers, __dispatch_fn_t __dispatch,
       rpcprot_t __protocol) __attribute__ ((__nothrow__ , __leaf__));
extern void svc_unregister (rpcprog_t __prog, rpcvers_t __vers) __attribute__ ((__nothrow__ , __leaf__));
extern void xprt_register (SVCXPRT *__xprt) __attribute__ ((__nothrow__ , __leaf__));
extern void xprt_unregister (SVCXPRT *__xprt) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t svc_sendreply (SVCXPRT *__xprt, xdrproc_t __xdr_results,
          caddr_t __xdr_location) __attribute__ ((__nothrow__ , __leaf__));
extern void svcerr_decode (SVCXPRT *__xprt) __attribute__ ((__nothrow__ , __leaf__));
extern void svcerr_weakauth (SVCXPRT *__xprt) __attribute__ ((__nothrow__ , __leaf__));
extern void svcerr_noproc (SVCXPRT *__xprt) __attribute__ ((__nothrow__ , __leaf__));
extern void svcerr_progvers (SVCXPRT *__xprt, rpcvers_t __low_vers,
     rpcvers_t __high_vers) __attribute__ ((__nothrow__ , __leaf__));
extern void svcerr_auth (SVCXPRT *__xprt, enum auth_stat __why) __attribute__ ((__nothrow__ , __leaf__));
extern void svcerr_noprog (SVCXPRT *__xprt) __attribute__ ((__nothrow__ , __leaf__));
extern void svcerr_systemerr (SVCXPRT *__xprt) __attribute__ ((__nothrow__ , __leaf__));
extern struct pollfd *svc_pollfd;
extern int svc_max_pollfd;
extern fd_set svc_fdset;
extern void svc_getreq (int __rdfds) __attribute__ ((__nothrow__ , __leaf__));
extern void svc_getreq_common (const int __fd) __attribute__ ((__nothrow__ , __leaf__));
extern void svc_getreqset (fd_set *__readfds) __attribute__ ((__nothrow__ , __leaf__));
extern void svc_getreq_poll (struct pollfd *, const int) __attribute__ ((__nothrow__ , __leaf__));
extern void svc_exit (void) __attribute__ ((__nothrow__ , __leaf__));
extern void svc_run (void) __attribute__ ((__nothrow__ , __leaf__));
extern SVCXPRT *svcraw_create (void) __attribute__ ((__nothrow__ , __leaf__));
extern SVCXPRT *svcudp_create (int __sock) __attribute__ ((__nothrow__ , __leaf__));
extern SVCXPRT *svcudp_bufcreate (int __sock, u_int __sendsz, u_int __recvsz)
     __attribute__ ((__nothrow__ , __leaf__));
extern SVCXPRT *svctcp_create (int __sock, u_int __sendsize, u_int __recvsize)
     __attribute__ ((__nothrow__ , __leaf__));
extern SVCXPRT *svcfd_create (int __sock, u_int __sendsize, u_int __recvsize)
     __attribute__ ((__nothrow__ , __leaf__));
extern SVCXPRT *svcunix_create (int __sock, u_int __sendsize, u_int __recvsize,
    char *__path) __attribute__ ((__nothrow__ , __leaf__));
extern enum auth_stat _authenticate (struct svc_req *__rqst,
         struct rpc_msg *__msg) __attribute__ ((__nothrow__ , __leaf__));
typedef bool_t (*resultproc_t) (caddr_t __resp, struct sockaddr_in *__raddr);
extern bool_t pmap_set (const u_long __program, const u_long __vers,
   int __protocol, u_short __port) __attribute__ ((__nothrow__ , __leaf__));
extern bool_t pmap_unset (const u_long __program, const u_long __vers)
     __attribute__ ((__nothrow__ , __leaf__));
extern struct pmaplist *pmap_getmaps (struct sockaddr_in *__address) __attribute__ ((__nothrow__ , __leaf__));
extern enum clnt_stat pmap_rmtcall (struct sockaddr_in *__addr,
        const u_long __prog,
        const u_long __vers,
        const u_long __proc,
        xdrproc_t __xdrargs,
        caddr_t __argsp, xdrproc_t __xdrres,
        caddr_t __resp, struct timeval __tout,
        u_long *__port_ptr) __attribute__ ((__nothrow__ , __leaf__));
extern enum clnt_stat clnt_broadcast (const u_long __prog,
          const u_long __vers,
          const u_long __proc, xdrproc_t __xargs,
          caddr_t __argsp, xdrproc_t __xresults,
          caddr_t __resultsp,
          resultproc_t __eachresult) __attribute__ ((__nothrow__ , __leaf__));
extern u_short pmap_getport (struct sockaddr_in *__address,
        const u_long __program,
        const u_long __version, u_int __protocol)
     __attribute__ ((__nothrow__ , __leaf__));
struct pmap {
 long unsigned pm_prog;
 long unsigned pm_vers;
 long unsigned pm_prot;
 long unsigned pm_port;
};
extern bool_t xdr_pmap (XDR *__xdrs, struct pmap *__regs) __attribute__ ((__nothrow__ , __leaf__));
struct pmaplist {
 struct pmap pml_map;
 struct pmaplist *pml_next;
};
extern bool_t xdr_pmaplist (XDR *__xdrs, struct pmaplist **__rp) __attribute__ ((__nothrow__ , __leaf__));
Compiler stderr:
 In file included from /usr/include/stdlib.h:24:0,
                 from /usr/include/rpc/types.h:60,
                 from /usr/include/tirpc/rpc/rpc.h:38,
                 from /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmpc_gl6r01/testfile.c:7:
/usr/include/features.h:330:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
In file included from /builddir/build/BUILD/liblxi-1.14/x86_64-redhat-linux-gnu/meson-private/tmpc_gl6r01/testfile.c:7:0:
/usr/include/tirpc/rpc/rpc.h:74:61: fatal error: rpc/rpcb_clnt.h: No such file or directory
 #include <rpc/rpcb_clnt.h> /* rpcbind interface functions */
                                                             ^
compilation terminated.
Has header "tirpc/rpc/rpc.h" : NO 
src/meson.build:23:2: ERROR: Problem encountered: Please install libtirpc headers
$ 
```