### PR TITLE
Fixed LXI connect error memory leak

### DIFF
--- a/src/lxi.c
+++ b/src/lxi.c
@@ -123,6 +123,8 @@ EXPORT int lxi_connect(const char *address, int port, const char *name, int time
     return i;
 
 error_connect:
+    if (session[i].data)
+        free(session[i].data);
 error_protocol:
 error_session:
     pthread_mutex_unlock(&session_mutex);


### PR DESCRIPTION
If connection failed, the previously malloc'd memory would not be released and re-allocated upon next connect retry.
Fixed by freeing if connection fails.