### PR TITLE
Fixed missing VXI11 connect-abort multithreading synchronization

### DIFF
--- a/src/vxi11.c
+++ b/src/vxi11.c
@@ -161,6 +161,10 @@ int vxi11_connect(void *data, const char *address, int port, const char *name, i
     {
         // Timeout reached
         pthread_cancel(thread);
+
+        // Wait for child thread to end before returning
+        pthread_join(thread, NULL);
+
         return -1;
     }
 


### PR DESCRIPTION
The end user might expect the lxi_connect() call to return synchronously; however, the separate connection thread may still be alive although already cancelled when the user calls lxi_connect() again.
pthread_cancel()'ing the child thread sends a termination signal, which is handled by the child. The parent should wait for the child to be fully terminated before returning. This does not notably block the call, but avoids creating more and more child threads when retrying to connect.