### PR TITLE
vxi11: do not fail on zero length messages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,5 +7,6 @@ Jakub Wilk <jwilk@jwilk.net>
 Dima Kogan <dima@secretsauce.net>
 Dmitri Goutnik <dg@syrec.org>
 zramudzuli <zramudzuli@ska.ac.za>
+Perry Hung <perry@mosi.io>
 
 Thanks to everyone who has contributed to this project.

--- a/src/vxi11.c
+++ b/src/vxi11.c
@@ -256,8 +256,6 @@ int vxi11_receive(void *data, char *message, int length, int timeout)
 
             offset += read_resp.data.data_len;
         }
-        else
-            return -1;
 
         // Stop if we have reached end of receive operation
         if ((read_resp.reason & RECEIVE_END_BIT) || (read_resp.reason & RECEIVE_TERM_CHAR_BIT))


### PR DESCRIPTION
Zero length messages are valid replies in VXI-11. Do not return an error
and prematurely exit.
    
Reads should be repeated until EOI or an error is encountered.