### PR TITLE
lxi_connection(vx11) can hang

### DIFF
--- a/src/vxi11.c
+++ b/src/vxi11.c
@@ -195,7 +195,12 @@ int vxi11_connect(void *data, const char *address, int port, const char *name, i
 
     // Convert timeout in ms to timespec
     timeout_tv.tv_sec += timeout / 1000;
-    timeout_tv.tv_nsec += (timeout % 1000) * 1000;
+    timeout_tv.tv_nsec += (timeout % 1000) * 1000000;
+    if (timeout_tv.tv_nsec >= 1000000000)
+    {
+        timeout_tv.tv_sec += 1;
+        timeout_tv.tv_nsec %= 1000000000;
+    }
 
     // Start thread that will perform the connect action
     status = pthread_create(&thread, NULL, thread_vxi11_connect, &args);


### PR DESCRIPTION
@lundmar little explanation bellow

How issue was seen:

On linux I change by accident setting screenshot timeout from 8000ms to 7900ms Run live view and app  hang sooner or later.

I made investigation and it show that call pthread_cond_timedwait return EINVAL in case of tv_nsec is higher then 1e9.

It can be also easily reproduced  with compile liblxie with follwing change:
change line in vx11.c
timeout_tv.tv_nsec += (timeout % 1000) * 1000;
to
timeout_tv.tv_nsec += ((timeout % 1000) * 1000)+1000000000;

run  scpi command *IDN? and program will hang immediatly

Issue confirmed on linux and windows. I don't have any apple machine to confirm.